### PR TITLE
Remove local codex-sdk-sync symlink and ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ ipython_config.py
 # pyenv
 .python-version
 codex-sdk-sync.skill
+codex-sdk-sync
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies


### PR DESCRIPTION
## Summary
- remove tracked `codex-sdk-sync` symlink that pointed to a local absolute path (`/Users/andreamaspero/...`)
- add `codex-sdk-sync` to `.gitignore` to prevent accidental re-addition

## Why
This avoids exposing local machine/user-identifying absolute paths in repository files and blame views.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to exclude additional build artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->