### PR TITLE
Fix pydantic-ai streaming compatibility and cut 0.104.1

### DIFF
--- a/CHANGELOG_SDK.md
+++ b/CHANGELOG_SDK.md
@@ -2,6 +2,22 @@
 
 This file tracks SDK-level changes. Keep the newest changes at the top.
 
+## [0.104.1] - 2026-02-25
+
+### Fixed
+- Fix pydantic-ai `request_stream` compatibility by accepting optional `run_context`
+  in `CodexModel.request_stream(...)`.
+- Add `CodexStreamedResponse.provider_url` for newer pydantic-ai stream interfaces.
+
+### Added
+- Reproduction harness examples for `Agent.run_stream(...)` and `Agent.run(...)`
+  with `CodexModel` to quickly verify streaming and non-stream integration paths.
+
+### Notes
+- Tested pydantic-ai-slim versions: `0.8.1` (repo baseline), `1.56.0`, and `1.63.0`.
+- Compatibility boundary verified from published wheels: `run_context` is introduced
+  in stream contracts starting at `pydantic-ai-slim 0.7.0`.
+
 ## [0.104.0] - 2026-02-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Embed the Codex agent in Python workflows. This SDK wraps the bundled `codex` CL
       <td><strong>Lifecycle</strong></td>
       <td>
         <a href="#ci-cd"><img src="https://img.shields.io/badge/CI%2FCD-Active-16a34a?style=flat&logo=githubactions&logoColor=white" alt="CI/CD badge" /></a>
-        <img src="https://img.shields.io/badge/Release-0.104.0-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release 0.104.0 badge" />
+        <img src="https://img.shields.io/badge/Release-0.104.1-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release 0.104.1 badge" />
         <a href="#license"><img src="https://img.shields.io/badge/License-Apache--2.0-0f766e?style=flat&logo=apache&logoColor=white" alt="License badge" /></a>
       </td>
     </tr>

--- a/examples/pydantic_ai_run_compat.py
+++ b/examples/pydantic_ai_run_compat.py
@@ -1,0 +1,100 @@
+"""Minimal harness for non-stream Agent.run parity with CodexModel."""
+
+import asyncio
+import json
+import re
+
+from pydantic_ai import Agent
+
+from codex_sdk.events import Usage
+from codex_sdk.integrations.pydantic_ai_model import CodexModel
+from codex_sdk.thread import ParsedTurn, Turn
+
+
+class _FakeThread:
+    def __init__(self) -> None:
+        self.id = "thread-compat-run"
+
+    async def run_json(self, prompt, *, output_schema, turn_options=None):
+        tool_names = (
+            output_schema.get("properties", {})
+            .get("tool_calls", {})
+            .get("items", {})
+            .get("properties", {})
+            .get("name", {})
+            .get("enum", [])
+        )
+        output = {"tool_calls": [], "final": "run ok"}
+        if tool_names:
+            first_tool = tool_names[0]
+            args_json = _build_args_json(prompt, first_tool)
+            output = {
+                "tool_calls": [
+                    {"id": "call_1", "name": first_tool, "arguments": args_json}
+                ],
+                "final": "",
+            }
+        turn = Turn(
+            items=[],
+            final_response="",
+            usage=Usage(input_tokens=1, cached_input_tokens=0, output_tokens=1),
+        )
+        return ParsedTurn(turn=turn, output=output)
+
+
+class _FakeCodex:
+    def __init__(self) -> None:
+        self._thread = _FakeThread()
+
+    def start_thread(self, options=None):
+        return self._thread
+
+
+def _build_args_json(prompt: str, tool_name: str) -> str:
+    pattern = re.compile(
+        rf"- {re.escape(tool_name)}\\n(?:  .*\\n)*?  parameters_json_schema: (.+)"
+    )
+    match = pattern.search(prompt)
+    if not match:
+        return "{}"
+    try:
+        schema = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return "{}"
+    value = _example_value(schema)
+    if isinstance(value, dict):
+        return json.dumps(value, separators=(",", ":"))
+    return "{}"
+
+
+def _example_value(schema):
+    schema_type = schema.get("type")
+    if schema_type == "object":
+        properties = schema.get("properties", {})
+        required = schema.get("required", [])
+        result = {}
+        keys = required or list(properties.keys())[:1]
+        for key in keys:
+            child_schema = properties.get(key, {"type": "string"})
+            result[key] = _example_value(child_schema)
+        return result
+    if schema_type == "array":
+        return []
+    if schema_type == "integer":
+        return 1
+    if schema_type == "number":
+        return 1.0
+    if schema_type == "boolean":
+        return True
+    return "ok"
+
+
+async def _main() -> None:
+    agent = Agent(model=CodexModel(codex=_FakeCodex()), output_type=str)
+    result = await agent.run("ping")
+    assert result.output == "run ok"
+    print("run compatible:", result.output)
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/examples/pydantic_ai_run_stream_compat.py
+++ b/examples/pydantic_ai_run_stream_compat.py
@@ -1,0 +1,110 @@
+"""Minimal harness reproducing Agent.run_stream + CodexModel compatibility."""
+
+import asyncio
+import json
+import re
+
+from pydantic_ai import Agent
+
+from codex_sdk.events import Usage
+from codex_sdk.integrations.pydantic_ai_model import CodexModel
+from codex_sdk.thread import ParsedTurn, Turn
+
+
+class _FakeThread:
+    def __init__(self) -> None:
+        self.id = "thread-compat-stream"
+
+    async def run_json(self, prompt, *, output_schema, turn_options=None):
+        tool_names = (
+            output_schema.get("properties", {})
+            .get("tool_calls", {})
+            .get("items", {})
+            .get("properties", {})
+            .get("name", {})
+            .get("enum", [])
+        )
+        output = {"tool_calls": [], "final": "stream ok"}
+        if tool_names:
+            first_tool = tool_names[0]
+            args_json = _build_args_json(prompt, first_tool)
+            output = {
+                "tool_calls": [
+                    {"id": "call_1", "name": first_tool, "arguments": args_json}
+                ],
+                "final": "",
+            }
+        turn = Turn(
+            items=[],
+            final_response="",
+            usage=Usage(input_tokens=1, cached_input_tokens=0, output_tokens=1),
+        )
+        return ParsedTurn(turn=turn, output=output)
+
+
+class _FakeCodex:
+    def __init__(self) -> None:
+        self._thread = _FakeThread()
+
+    def start_thread(self, options=None):
+        return self._thread
+
+
+def _build_args_json(prompt: str, tool_name: str) -> str:
+    pattern = re.compile(
+        rf"- {re.escape(tool_name)}\\n(?:  .*\\n)*?  parameters_json_schema: (.+)"
+    )
+    match = pattern.search(prompt)
+    if not match:
+        return "{}"
+    try:
+        schema = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return "{}"
+    value = _example_value(schema)
+    if isinstance(value, dict):
+        return json.dumps(value, separators=(",", ":"))
+    return "{}"
+
+
+def _example_value(schema):
+    schema_type = schema.get("type")
+    if schema_type == "object":
+        properties = schema.get("properties", {})
+        required = schema.get("required", [])
+        result = {}
+        keys = required or list(properties.keys())[:1]
+        for key in keys:
+            child_schema = properties.get(key, {"type": "string"})
+            result[key] = _example_value(child_schema)
+        return result
+    if schema_type == "array":
+        return []
+    if schema_type == "integer":
+        return 1
+    if schema_type == "number":
+        return 1.0
+    if schema_type == "boolean":
+        return True
+    return "ok"
+
+
+async def _main() -> None:
+    agent = Agent(model=CodexModel(codex=_FakeCodex()), output_type=str)
+    try:
+        async with agent.run_stream("ping") as result:
+            output = await result.get_output()
+    except TypeError as exc:
+        raise AssertionError(f"run_stream raised TypeError: {exc}") from exc
+    except Exception as exc:
+        print(
+            "run_stream invoked without TypeError "
+            f"(raised {type(exc).__name__}: {exc})"
+        )
+        return
+
+    print("run_stream compatible:", output)
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "codex-sdk-python"
-version = "0.104.0"
+version = "0.104.1"
 description = "Python SDK for the Codex CLI agent with async threads, streaming events, and structured outputs"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/codex_sdk/__init__.py
+++ b/src/codex_sdk/__init__.py
@@ -79,7 +79,7 @@ from .thread import (
     Turn,
 )
 
-__version__ = "0.104.0"
+__version__ = "0.104.1"
 
 __all__ = [
     "AbortController",

--- a/src/codex_sdk/integrations/pydantic_ai_model.py
+++ b/src/codex_sdk/integrations/pydantic_ai_model.py
@@ -392,6 +392,11 @@ class CodexStreamedResponse(StreamedResponse):
         return self._provider_name
 
     @property
+    def provider_url(self) -> Optional[str]:
+        """Return the provider URL when available (Codex currently does not expose one)."""
+        return None
+
+    @property
     def timestamp(self) -> datetime:
         """
         Get the UTC timestamp when this response was created.
@@ -627,6 +632,7 @@ class CodexModel(Model):
         messages: list[ModelMessage],
         model_settings: Optional[ModelSettings],
         model_request_parameters: ModelRequestParameters,
+        run_context: Optional[Any] = None,
     ) -> AsyncIterator[StreamedResponse]:
         """
         Produce an asynchronous stream that yields a Codex-backed streamed model response for the given message sequence.
@@ -635,6 +641,8 @@ class CodexModel(Model):
             messages: Conversation messages to send to the model.
             model_settings: Model-specific settings (may be None).
             model_request_parameters: Additional request parameters controlling the model call.
+            run_context: Optional PydanticAI run context. Accepted for compatibility
+                with PydanticAI stream-call contracts and currently unused by Codex.
 
         Returns:
             An async iterator that yields a single StreamedResponse (CodexStreamedResponse) containing the model name, response parts, usage information, and the Codex thread identifier.

--- a/tests/test_pydantic_ai_model.py
+++ b/tests/test_pydantic_ai_model.py
@@ -1,5 +1,6 @@
 import dataclasses
 import importlib
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -27,8 +28,10 @@ from codex_sdk.thread import ParsedTurn, Turn
 
 messages = importlib.import_module("pydantic_ai.messages")
 models = importlib.import_module("pydantic_ai.models")
+pydantic_ai = importlib.import_module("pydantic_ai")
 tools = importlib.import_module("pydantic_ai.tools")
 
+Agent = pydantic_ai.Agent
 BuiltinToolCallPart = messages.BuiltinToolCallPart
 ModelRequest = messages.ModelRequest
 ModelResponse = messages.ModelResponse
@@ -523,6 +526,62 @@ async def test_codex_model_request_stream_yields_response():
     assert response.provider_details == {"thread_id": "thread-123"}
 
 
+@pytest.mark.asyncio
+async def test_codex_model_request_stream_accepts_run_context_argument():
+    output = {"tool_calls": [], "final": "hello"}
+    thread = FakeThread(output)
+    codex = FakeCodex(thread)
+    model = CodexModel(codex=codex)
+
+    messages = [ModelRequest(parts=[UserPromptPart("hi")])]
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    async with model.request_stream(messages, None, params, object()) as streamed:
+        _ = [event async for event in streamed]
+        response = streamed.get()
+
+    assert len(response.parts) == 1
+    assert isinstance(response.parts[0], TextPart)
+    assert response.parts[0].content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_agent_run_stream_passes_run_context_to_codex_model():
+    class CapturingCodexModel(CodexModel):
+        def __init__(self, *, codex):
+            super().__init__(codex=codex)
+            self.last_run_context = None
+
+        @asynccontextmanager
+        async def request_stream(
+            self,
+            messages,
+            model_settings,
+            model_request_parameters,
+            run_context=None,
+        ):
+            self.last_run_context = run_context
+            async with super().request_stream(
+                messages,
+                model_settings,
+                model_request_parameters,
+                run_context,
+            ) as streamed:
+                yield streamed
+
+    output = {"tool_calls": [], "final": "hello"}
+    thread = FakeThread(output)
+    codex = FakeCodex(thread)
+    model = CapturingCodexModel(codex=codex)
+    agent = Agent(model=model, output_type=str)
+
+    async with agent.run_stream("hi") as result:
+        streamed_output = await result.get_output()
+
+    assert streamed_output == "hello"
+    assert model.last_run_context is not None
+
+
 def test_codex_model_can_construct_codex_from_options():
     CodexModel(codex_options=CodexOptions(codex_path_override="codex-binary"))
 
@@ -547,3 +606,4 @@ async def test_streamed_response_emits_tool_calls_and_skips_unknown_parts():
     )
     events = [event async for event in resp]
     assert events
+    assert resp.provider_url is None

--- a/uv.lock
+++ b/uv.lock
@@ -680,7 +680,7 @@ wheels = [
 
 [[package]]
 name = "codex-sdk-python"
-version = "0.104.0"
+version = "0.104.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
Fixes production streaming incompatibilities between `codex-sdk-python` and `pydantic-ai` by aligning the Codex integration with the stream contract used by `Agent.run_stream(...)`.

## Root Cause
- `CodexModel.request_stream` did not accept `run_context`, while pydantic-ai stream callers pass it.
- On newer pydantic-ai versions, streamed responses also require `provider_url` in the `StreamedResponse` interface.
- Non-stream paths were unaffected because `request(...)` has no `run_context` argument.

## Changes
- Update `CodexModel.request_stream` signature to accept optional `run_context` (currently ignored).
- Add `CodexStreamedResponse.provider_url` property for interface compatibility.
- Add regression tests for:
  - direct `request_stream(..., run_context)` invocation
  - `Agent.run_stream(...)` passing a non-`None` run context
  - streamed response `provider_url`
- Add reproduction harness scripts:
  - `examples/pydantic_ai_run_stream_compat.py`
  - `examples/pydantic_ai_run_compat.py`
- Patch release prep:
  - bump package version to `0.104.1` (`pyproject.toml`, `src/codex_sdk/__init__.py`, `README.md` badge, `uv.lock`)
  - add changelog entry in `CHANGELOG_SDK.md`

## Validation
- `uv run pytest -q` -> `235 passed`
- `uv run python examples/pydantic_ai_run_stream_compat.py`
- `uv run python examples/pydantic_ai_run_compat.py`

## Compatibility Notes
- Verified pydantic-ai stream contract boundary: `run_context` appears starting from `pydantic-ai-slim 0.7.0`.
- Tested in this change: `0.8.1` (repo baseline), `1.56.0`, `1.63.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.104.1

* **New Features**
  * Added `provider_url` property to streaming responses
  * Extended streaming API with optional `run_context` parameter support

* **Bug Fixes**
  * Improved PydanticAI compatibility for streaming operations

* **Documentation**
  * Added example scripts demonstrating Agent.run_stream and Agent.run with CodexModel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->