### PR TITLE
Release 0.105.0: direct binary download path, CI hardening, and docs accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,8 @@ jobs:
       - name: Sync dependencies
         run: uv sync --locked --all-extras --dev
 
+      - name: Download Codex binaries
+        run: python scripts/setup_binary.py
+
       - name: Test
         run: uv run pytest --cov=codex_sdk --cov-report=term-missing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 
 ## Build, Test, and Development Commands
 - `uv sync` installs dev dependencies from `pyproject.toml`.
-- `python scripts/setup_binary.py` downloads and installs the Codex CLI binaries (requires Node.js/npm).
-  It resolves the latest `@openai/codex` version and assembles per-platform npm artifacts into `src/codex_sdk/vendor/`.
+- `python scripts/setup_binary.py` downloads and installs the Codex CLI binaries (direct registry download by default; no Node.js/npm required).
+  It resolves the latest `@openai/codex` version and assembles per-platform artifacts into `src/codex_sdk/vendor/`.
 - `python examples/basic_usage.py` runs a quick smoke test of the SDK.
 - `uv run pytest` runs the test suite.
 - `uv run pytest --cov=codex_sdk` runs tests with coverage enforcement.

--- a/CHANGELOG_SDK.md
+++ b/CHANGELOG_SDK.md
@@ -2,21 +2,33 @@
 
 This file tracks SDK-level changes. Keep the newest changes at the top.
 
-## [0.104.1] - 2026-02-25
+## [Unreleased]
+
+## [0.105.0] - 2026-02-26
 
 ### Fixed
-- Fix pydantic-ai `request_stream` compatibility by accepting optional `run_context`
+- Fix pydantic-ai request_stream compatibility by accepting optional `run_context`
   in `CodexModel.request_stream(...)`.
 - Add `CodexStreamedResponse.provider_url` for newer pydantic-ai stream interfaces.
 
-### Added
-- Reproduction harness examples for `Agent.run_stream(...)` and `Agent.run(...)`
-  with `CodexModel` to quickly verify streaming and non-stream integration paths.
+### Updated
+- README architecture and systems documentation now reflects both transport paths:
+  `codex exec --experimental-json` (Thread API) and `codex app-server` (JSON-RPC).
+- README PydanticAI streaming notes now document compatibility semantics (stream
+  interface support with response parts emitted after the underlying JSON turn).
+- README CI/CD and binary setup sections expanded with explicit workflow details and
+  guidance for CI environments that download Codex binaries.
+- CI test workflow now runs `python scripts/setup_binary.py` before pytest, so
+  tests do not require committing updated vendor binaries.
+- `scripts/setup_binary.py` now supports direct registry downloads by default
+  (no npm/Node dependency required), with optional `CODEX_SETUP_TRANSPORT=npm`
+  for npm-pack mode.
+- SDK package version bumped to `0.105.0` (`pyproject.toml`,
+  `codex_sdk.__version__`, README release badge).
 
 ### Notes
-- Tested pydantic-ai-slim versions: `0.8.1` (repo baseline), `1.56.0`, and `1.63.0`.
-- Compatibility boundary verified from published wheels: `run_context` is introduced
-  in stream contracts starting at `pydantic-ai-slim 0.7.0`.
+- Tested with pydantic-ai-slim versions from `0.8.1` through `1.63.0`
+  (including `1.56.0` and `1.63.0` stream invocation checks).
 
 ## [0.104.0] - 2026-02-18
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Embed the Codex agent in Python workflows. This SDK wraps the bundled `codex` CL
       <td><strong>Lifecycle</strong></td>
       <td>
         <a href="#ci-cd"><img src="https://img.shields.io/badge/CI%2FCD-Active-16a34a?style=flat&logo=githubactions&logoColor=white" alt="CI/CD badge" /></a>
-        <img src="https://img.shields.io/badge/Release-0.104.1-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release 0.104.1 badge" />
+        <img src="https://img.shields.io/badge/Release-0.105.0-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release 0.105.0 badge" />
         <a href="#license"><img src="https://img.shields.io/badge/License-Apache--2.0-0f766e?style=flat&logo=apache&logoColor=white" alt="License badge" /></a>
       </td>
     </tr>
@@ -37,7 +37,7 @@ Embed the Codex agent in Python workflows. This SDK wraps the bundled `codex` CL
 </div>
 
 - Runtime dependency-free: uses only the Python standard library.
-- Codex CLI binaries are downloaded separately; use `scripts/setup_binary.py` from the repo or install the Codex CLI and set `codex_path_override`.
+- Codex CLI binaries can be sourced either from the vendored `src/codex_sdk/vendor/` tree (when present) or from a system-installed `codex` binary (`codex_path_override` supported).
 - Async-first API with sync helpers, streaming events, and structured output.
 - Python 3.8/3.9 support is deprecated and will be removed in a future release; use Python 3.10+.
 
@@ -132,6 +132,8 @@ python examples/app_server_turn_session.py
 python examples/config_overrides.py
 python examples/hooks_streaming.py
 python examples/notify_hook.py
+python examples/pydantic_ai_run_compat.py
+python examples/pydantic_ai_run_stream_compat.py
 ```
 
 <a id="features"></a>
@@ -148,6 +150,15 @@ python examples/notify_hook.py
 | ![PydanticAI](https://img.shields.io/badge/PydanticAI-Model%20Provider-0b3b2e?style=flat&logo=pydantic&logoColor=white) | Codex can act as a PydanticAI model or as a delegated tool.            |
 | ![Abort](https://img.shields.io/badge/Abort-Signals-ef4444?style=flat&logo=gnubash&logoColor=white)                | Cancel running turns via `AbortController` and `AbortSignal`.           |
 | ![Telemetry](https://img.shields.io/badge/Telemetry-Logfire%20Spans-f97316?style=flat&logo=simpleicons&logoColor=white) | Optional spans if Logfire is installed and initialized.                 |
+
+### Execution surfaces and transports
+
+| Surface | Primary transport | Typical use |
+| ------- | ----------------- | ----------- |
+| `Codex` + `Thread` | `codex exec --experimental-json` (JSONL over stdio) | Conversational turns, streaming item events, structured output (`run_json` / `run_pydantic`). |
+| `AppServerClient` | `codex app-server` (JSON-RPC over stdio) | Full app-server protocol: thread management, turn sessions, approvals, account/config/skills APIs. |
+| `CodexModel` (PydanticAI provider) | `Thread.run_json(...)` on top of `codex exec` | Tool-call planning + optional final text via strict JSON envelope. |
+| `codex_handoff_tool` (PydanticAI tool) | `Thread.run(...)` on top of `codex exec` | Delegate repository-aware tasks from another model to Codex. |
 
 <a id="configuration"></a>
 ## ![Configuration](https://img.shields.io/badge/Configuration-Options%20%26%20Env-0ea5e9?style=for-the-badge&logo=json&logoColor=white)
@@ -276,6 +287,10 @@ For richer integrations (thread fork, requirements, explicit skill input), use t
 protocol. The client handles the initialize/initialized handshake and gives you access to
 JSON-RPC notifications.
 
+`AppServerClient` starts `codex app-server` and multiplexes notifications + server-initiated
+requests (for example approval requests in `turn_session(...)`) on top of the same stdio
+connection.
+
 ```python
 import asyncio
 from codex_sdk import AppServerClient, AppServerOptions
@@ -390,6 +405,11 @@ Supported target triples:
 If you are working from source and the vendor directory is missing, run
 `python scripts/setup_binary.py` to fetch and assemble the platform `@openai/codex`
 artifacts into `src/codex_sdk/vendor/`.
+
+`scripts/setup_binary.py` behavior:
+- Resolves `CODEX_NPM_VERSION` when set; otherwise resolves latest `@openai/codex`.
+- Tries legacy `@openai/codex-sdk` package first, then falls back to per-target `@openai/codex@<version>-<suffix>` artifacts.
+- Rebuilds `src/codex_sdk/vendor/` for all supported targets and validates current-platform binary presence.
 
 <a id="auth"></a>
 ## ![Auth](https://img.shields.io/badge/Auth%20%26%20Credentials-Access-2563eb?style=for-the-badge&logo=gnubash&logoColor=white)
@@ -597,6 +617,8 @@ Example scripts under `examples/`:
 - `notify_hook.py`: notify script for CLI callbacks.
 - `pydantic_ai_model_provider.py`: Codex as a PydanticAI model provider.
 - `pydantic_ai_handoff.py`: Codex as a PydanticAI tool.
+- `pydantic_ai_run_compat.py`: minimal compatibility harness for `Agent.run(...)`.
+- `pydantic_ai_run_stream_compat.py`: minimal compatibility harness for `Agent.run_stream(...)`.
 
 <a id="sandbox"></a>
 ## ![Sandbox](https://img.shields.io/badge/Sandbox-Permissions%20%26%20Safety-1f2937?style=for-the-badge&logo=gnubash&logoColor=white)
@@ -649,8 +671,9 @@ How it works:
 - `CodexModel` builds a JSON schema envelope with `tool_calls` and `final`.
 - Codex emits tool calls as JSON strings; PydanticAI runs them.
 - If `allow_text_output` is true, Codex can place final text in `final`.
-- Streaming APIs (`Agent.run_stream_events()`, `Agent.run_stream_sync()`) are supported; Codex
-  emits streamed responses as a single chunk once the turn completes.
+- Streaming APIs (`Agent.run_stream(...)`, `Agent.run_stream_events()`, `Agent.run_stream_sync()`)
+  are supported for compatibility; response parts are emitted after the underlying `run_json(...)`
+  turn completes (not token-by-token from Codex).
 
 Safety defaults (you can override with your own `ThreadOptions`):
 - `sandbox_mode="read-only"`
@@ -713,38 +736,47 @@ If `logfire` is installed and initialized, the SDK emits spans:
 If Logfire is missing or not initialized, the span context manager is a no-op.
 
 <a id="architecture"></a>
-<a id="acheature"></a>
 ## ![Architecture](https://img.shields.io/badge/Architecture-Stack%20map-1f2937?style=for-the-badge&logo=serverless&logoColor=white)
 
-### System components
+### System components and transport paths
 
 ```mermaid
 flowchart LR
   subgraph App[Your Python App]
     U[User Code]
-    T[Thread API]
+    T[Codex + Thread API]
+    A[AppServerClient API]
+    M[PydanticAI Integrations]
   end
 
   subgraph SDK[Codex SDK]
     C[Codex]
     E[CodexExec]
-    P[Event Parser]
+    P[Thread Event Parser]
+    R[JSON-RPC Client]
   end
 
-  subgraph CLI[Bundled Codex CLI]
+  subgraph CLI[Codex CLI]
     X["codex exec --experimental-json"]
+    S["codex app-server"]
   end
 
   FS[(Filesystem)]
   NET[(Network)]
 
   U --> T --> C --> E --> X
+  U --> A --> R --> S
+  U --> M
+  M --> C
   X -->|JSONL events| P --> T
+  S -->|JSON-RPC messages| R --> A
   X --> FS
   X --> NET
+  S --> FS
+  S --> NET
 ```
 
-### Streaming event lifecycle
+### Thread API streaming lifecycle (`codex exec`)
 
 ```mermaid
 sequenceDiagram
@@ -767,7 +799,29 @@ sequenceDiagram
   Thread-->>Dev: turn.completed / turn.failed
 ```
 
-### PydanticAI model-provider loop
+### App-server lifecycle (`codex app-server`)
+
+```mermaid
+sequenceDiagram
+  participant Dev as Developer
+  participant App as AppServerClient
+  participant CLI as codex app-server
+
+  Dev->>App: start()
+  App->>CLI: spawn process
+  App->>CLI: initialize
+  CLI-->>App: initialize result
+  App->>CLI: initialized (notification)
+  Dev->>App: turn_session(thread_id, input)
+  App->>CLI: turn/start
+  CLI-->>App: thread/turn/item notifications
+  CLI-->>App: request (approval needed)
+  App-->>CLI: response (approve/reject)
+  CLI-->>App: turn completed notification
+  App-->>Dev: final turn payload
+```
+
+### PydanticAI model-provider loop (current implementation)
 
 ```mermaid
 sequenceDiagram
@@ -797,11 +851,17 @@ sequenceDiagram
 flowchart LR
   Agent[PydanticAI Agent] --> Tool[codex_handoff_tool]
   Tool --> SDK[Codex SDK Thread]
-  SDK --> CLI[Codex CLI]
+  SDK --> CLI[codex exec]
   CLI --> SDK
   SDK --> Tool
   Tool --> Agent
 ```
+
+### Streaming semantics summary
+
+- `Thread.run_streamed()` and `Thread.run_streamed_events()` stream incremental `ThreadEvent` values as JSONL lines arrive from `codex exec`.
+- `AppServerClient.notifications()` streams incremental JSON-RPC notifications from `codex app-server`.
+- `CodexModel.request_stream(...)` exposes a stream-compatible interface for PydanticAI, but events are emitted from an already-completed `run_json(...)` result.
 
 <a id="testing"></a>
 ## ![Testing](https://img.shields.io/badge/Testing-Pytest%20%26%20Coverage-2563eb?style=for-the-badge&logo=pytest&logoColor=white)
@@ -811,9 +871,12 @@ This repo uses unit tests with mocked CLI processes to keep the test suite fast 
 Test focus areas:
 - `tests/test_exec.py`: CLI invocation, environment handling, config flags, abort behavior.
 - `tests/test_thread.py`: parsing, streaming, JSON schema, Pydantic validation, input normalization.
+- `tests/test_app_server.py` and `tests/test_app_server_session.py`: JSON-RPC lifecycle, method wrappers, turn-session approvals/notifications.
 - `tests/test_codex.py`: resume helpers and option wiring.
+- `tests/test_config_overrides.py`: `--config` serialization and merge behavior.
 - `tests/test_abort.py`: abort signal semantics.
 - `tests/test_telemetry.py`: Logfire span behavior.
+- `tests/test_tool_envelope.py`: tool envelope parsing and schema normalization helpers.
 - `tests/test_pydantic_ai_*`: PydanticAI model provider and handoff integration.
 
 ### Run tests
@@ -855,10 +918,21 @@ uv run mypy src
 ## ![CI/CD](https://img.shields.io/badge/CI%2FCD-Overview-1F4B99?style=for-the-badge&logo=gnubash&logoColor=white)
 
 This repository includes GitHub Actions workflows under `.github/workflows/`.
-The CI pipeline runs linting, type checks, and `pytest --cov=codex_sdk`.
-Release automation creates GitHub releases from `CHANGELOG_SDK.md` when you push a
-`vX.Y.Z` tag or manually dispatch the workflow, then the publish workflow uploads
-the package to PyPI on release publish.
+
+Current workflows:
+- `ci.yml`: lint (`black`, `isort`, `flake8`), type-check (`mypy`), and tests (`pytest --cov=codex_sdk`) on Python 3.10/3.11/3.12.
+- `release.yml`: extracts release notes from `CHANGELOG_SDK.md` and creates a GitHub Release for `vX.Y.Z`.
+- `publish.yml`: builds (`uv build --no-sources`) and publishes to PyPI on release publish (or successful release workflow).
+- `docs-deploy.yml`: optional docs deployment (gated by `DOCS_DEPLOY_ENABLED`).
+- `uv-lock-update.yml`: scheduled weekly lockfile refresh PR.
+
+`ci.yml` test jobs install Node.js and run:
+
+```bash
+python scripts/setup_binary.py
+```
+
+before `pytest`, so test runs do not depend on committed vendor binary updates.
 
 <a id="operations"></a>
 ## ![Operations](https://img.shields.io/badge/Operations-Health%20%26%20Sessions-10b981?style=for-the-badge&logo=serverless&logoColor=white)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["uv_build>=0.9.21,<0.11.0"]
+requires = ["uv_build>=0.9.21,<0.10.0"]
 build-backend = "uv_build"
 
 [project]
 name = "codex-sdk-python"
-version = "0.104.1"
+version = "0.105.0"
 description = "Python SDK for the Codex CLI agent with async threads, streaming events, and structured outputs"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/setup_binary.py
+++ b/scripts/setup_binary.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
-"""Download and install vendored Codex CLI binaries for the Python SDK."""
+"""Download and install vendored Codex CLI binaries for the Python SDK.
 
+By default this script downloads package tarballs directly from the npm registry API
+and does not require Node.js/npm.
+"""
+
+import json
 import os
 import platform
 import shutil
@@ -8,7 +13,10 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
 
 TARGET_TO_SUFFIX = {
     "aarch64-apple-darwin": "darwin-arm64",
@@ -18,6 +26,72 @@ TARGET_TO_SUFFIX = {
     "aarch64-pc-windows-msvc": "win32-arm64",
     "x86_64-pc-windows-msvc": "win32-x64",
 }
+
+NPM_REGISTRY_URL = "https://registry.npmjs.org"
+
+
+def get_transport() -> str:
+    """Return the package download transport mode."""
+    requested = os.environ.get("CODEX_SETUP_TRANSPORT", "direct").strip().lower()
+    if requested not in {"direct", "npm"}:
+        print(
+            f"WARNING: Unknown CODEX_SETUP_TRANSPORT={requested!r}; "
+            "falling back to 'direct'."
+        )
+        return "direct"
+    return requested
+
+
+def _registry_json(path: str) -> dict:
+    """Fetch and decode JSON from the npm registry."""
+    url = f"{NPM_REGISTRY_URL}/{path.lstrip('/')}"
+    request = Request(url, headers={"Accept": "application/json"})
+    with urlopen(request) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _download_file(url: str, destination: Path) -> None:
+    """Download a URL to a destination path."""
+    request = Request(url)
+    with urlopen(request) as response, destination.open("wb") as handle:
+        shutil.copyfileobj(response, handle)
+
+
+def _download_tarball_from_registry(
+    package_name: str, package_version: str, destination_dir: Path
+) -> Optional[Path]:
+    """
+    Download a package tarball from npm registry metadata.
+
+    Returns:
+        Path to the downloaded tarball, or None if that package version does not exist.
+    """
+    encoded_name = quote(package_name, safe="")
+    encoded_version = quote(package_version, safe="")
+    metadata_path = f"{encoded_name}/{encoded_version}"
+
+    try:
+        metadata = _registry_json(metadata_path)
+    except HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+    except URLError as exc:
+        raise RuntimeError(
+            f"Failed to reach npm registry for {package_name}@{package_version}"
+        ) from exc
+
+    tarball_url = metadata.get("dist", {}).get("tarball")
+    if not tarball_url:
+        raise RuntimeError(
+            f"npm registry metadata missing dist.tarball for "
+            f"{package_name}@{package_version}"
+        )
+
+    file_name = tarball_url.rsplit("/", 1)[-1]
+    tarball_path = destination_dir / file_name
+    _download_file(tarball_url, tarball_path)
+    return tarball_path
 
 
 def run_command(cmd, cwd=None, check=True):
@@ -37,27 +111,31 @@ def run_command(cmd, cwd=None, check=True):
         raise
 
 
-def check_dependencies():
-    """Check if required dependencies are installed."""
-    print("Checking dependencies...")
+def check_dependencies(transport: str) -> bool:
+    """Check runtime dependencies for the selected transport mode."""
+    print(f"Checking dependencies for transport='{transport}'...")
 
-    # Check if npm is available
+    if transport == "direct":
+        print("OK: direct transport selected (no npm dependency).")
+        return True
+
+    # npm mode
     try:
         result = run_command(["npm", "--version"], check=False)
         if result.returncode != 0:
             print("ERROR: npm is not installed. Please install Node.js and npm first.")
-            print("   You can install it with: conda install nodejs")
+            print("   Or use CODEX_SETUP_TRANSPORT=direct")
             return False
         print(f"OK: npm version: {result.stdout.strip()}")
     except FileNotFoundError:
         print("ERROR: npm is not found. Please install Node.js and npm first.")
-        print("   You can install it with: conda install nodejs")
+        print("   Or use CODEX_SETUP_TRANSPORT=direct")
         return False
 
     return True
 
 
-def resolve_codex_version() -> str:
+def resolve_codex_version(transport: str) -> str:
     """Resolve the Codex npm version to install."""
     requested = os.environ.get("CODEX_NPM_VERSION", "").strip()
     if requested:
@@ -65,10 +143,18 @@ def resolve_codex_version() -> str:
         return requested
 
     print("Resolving latest @openai/codex version...")
-    result = run_command(["npm", "view", "@openai/codex", "version"])
-    version = result.stdout.strip()
+    if transport == "npm":
+        result = run_command(["npm", "view", "@openai/codex", "version"])
+        version = result.stdout.strip()
+        if not version:
+            raise RuntimeError("Could not resolve @openai/codex version from npm")
+        print(f"Resolved @openai/codex version: {version}")
+        return version
+
+    latest = _registry_json(f"{quote('@openai/codex', safe='')}/latest")
+    version = latest.get("version", "").strip()
     if not version:
-        raise RuntimeError("Could not resolve @openai/codex version from npm")
+        raise RuntimeError("Could not resolve @openai/codex latest version from registry")
     print(f"Resolved @openai/codex version: {version}")
     return version
 
@@ -83,9 +169,9 @@ def extract_tarball(tarball_path: Path, destination: Path) -> Path:
     return package_dir
 
 
-def download_codex_packages(version: str) -> Tuple[Path, List[Path]]:
+def download_codex_packages(version: str, transport: str) -> Tuple[Path, List[Path]]:
     """Download package(s) that contain vendor binaries for all target platforms."""
-    print("Downloading Codex npm packages...")
+    print(f"Downloading Codex packages (transport='{transport}')...")
 
     temp_dir = Path(tempfile.mkdtemp(prefix="codex-setup-"))
     print(f"Using temporary directory: {temp_dir}")
@@ -94,15 +180,24 @@ def download_codex_packages(version: str) -> Tuple[Path, List[Path]]:
 
     # Older releases bundled all targets in @openai/codex-sdk. Keep this path for
     # backwards compatibility.
-    sdk_spec = f"@openai/codex-sdk@{version}"
-    sdk_pack = run_command(["npm", "pack", sdk_spec], cwd=temp_dir, check=False)
-    if sdk_pack.returncode == 0:
-        sdk_tgz = next(temp_dir.glob("openai-codex-sdk-*.tgz"), None)
-        if sdk_tgz is not None:
-            sdk_package_dir = extract_tarball(sdk_tgz, temp_dir / "codex-sdk")
-            if (sdk_package_dir / "vendor").exists():
-                print(f"Found vendored binaries in {sdk_spec}")
-                package_dirs.append(sdk_package_dir)
+    legacy_package = "@openai/codex-sdk"
+    legacy_tarball: Optional[Path] = None
+    if transport == "npm":
+        sdk_spec = f"{legacy_package}@{version}"
+        sdk_pack = run_command(["npm", "pack", sdk_spec], cwd=temp_dir, check=False)
+        if sdk_pack.returncode == 0:
+            legacy_tarball = next(temp_dir.glob("openai-codex-sdk-*.tgz"), None)
+    else:
+        print(f"Trying legacy bundle {legacy_package}@{version} via registry API...")
+        legacy_tarball = _download_tarball_from_registry(
+            legacy_package, version, temp_dir
+        )
+
+    if legacy_tarball is not None:
+        sdk_package_dir = extract_tarball(legacy_tarball, temp_dir / "codex-sdk")
+        if (sdk_package_dir / "vendor").exists():
+            print(f"Found vendored binaries in {legacy_package}@{version}")
+            package_dirs.append(sdk_package_dir)
 
     if package_dirs:
         return temp_dir, package_dirs
@@ -112,27 +207,43 @@ def download_codex_packages(version: str) -> Tuple[Path, List[Path]]:
         "(new packaging format)."
     )
     for target, suffix in TARGET_TO_SUFFIX.items():
-        spec = f"@openai/codex@{version}-{suffix}"
-        print(f"Downloading {spec} for {target}")
-        packed = run_command(["npm", "pack", spec], cwd=temp_dir, check=False)
-        if packed.returncode != 0:
-            print(
-                "WARNING: npm pack failed for "
-                f"{target} ({suffix}); skipping this target."
-            )
-            if packed.stderr:
-                print(packed.stderr.strip())
-            continue
-        tarball = temp_dir / f"openai-codex-{version}-{suffix}.tgz"
-        if not tarball.exists():
-            matches = list(temp_dir.glob(f"openai-codex-*{suffix}.tgz"))
-            if len(matches) != 1:
+        package_name = "@openai/codex"
+        package_version = f"{version}-{suffix}"
+        print(f"Downloading {package_name}@{package_version} for {target}")
+
+        tarball: Optional[Path] = None
+        if transport == "npm":
+            spec = f"{package_name}@{package_version}"
+            packed = run_command(["npm", "pack", spec], cwd=temp_dir, check=False)
+            if packed.returncode != 0:
                 print(
-                    "WARNING: Could not locate tarball for "
+                    "WARNING: npm pack failed for "
                     f"{target} ({suffix}); skipping this target."
                 )
+                if packed.stderr:
+                    print(packed.stderr.strip())
                 continue
-            tarball = matches[0]
+            tarball = temp_dir / f"openai-codex-{version}-{suffix}.tgz"
+            if not tarball.exists():
+                matches = list(temp_dir.glob(f"openai-codex-*{suffix}.tgz"))
+                if len(matches) != 1:
+                    print(
+                        "WARNING: Could not locate tarball for "
+                        f"{target} ({suffix}); skipping this target."
+                    )
+                    continue
+                tarball = matches[0]
+        else:
+            tarball = _download_tarball_from_registry(
+                package_name, package_version, temp_dir
+            )
+            if tarball is None:
+                print(
+                    "WARNING: No registry tarball found for "
+                    f"{package_name}@{package_version}; skipping this target."
+                )
+                continue
+
         package_dir = extract_tarball(tarball, temp_dir / f"platform-{suffix}")
         vendor_dir = package_dir / "vendor"
         if not vendor_dir.exists():
@@ -297,6 +408,8 @@ def main():
     print("Codex Python SDK Setup")
     print("=" * 40)
     print()
+    transport = get_transport()
+    print(f"Transport mode: {transport}")
 
     # Get the SDK directory (where this script is located)
     sdk_dir = Path(__file__).resolve().parent.parent
@@ -305,12 +418,12 @@ def main():
     temp_dir = None
     try:
         # Check dependencies
-        if not check_dependencies():
+        if not check_dependencies(transport):
             return 1
 
         # Resolve target version and download vendor packages
-        version = resolve_codex_version()
-        temp_dir, package_dirs = download_codex_packages(version)
+        version = resolve_codex_version(transport)
+        temp_dir, package_dirs = download_codex_packages(version, transport)
 
         # Setup vendor directory
         vendor_dir = setup_vendor_directory(package_dirs, sdk_dir)
@@ -329,9 +442,9 @@ def main():
     except Exception as e:
         print(f"\nERROR: Setup failed: {e}")
         print("\nTroubleshooting:")
-        print("1. Make sure you have Node.js and npm installed")
+        print("1. Verify network connectivity to registry.npmjs.org")
         print("2. Check your internet connection")
-        print("3. Try running: conda install nodejs")
+        print("3. For npm-based download mode, set CODEX_SETUP_TRANSPORT=npm")
         return 1
     finally:
         if temp_dir is not None:

--- a/scripts/setup_binary.py
+++ b/scripts/setup_binary.py
@@ -15,7 +15,7 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional, Tuple
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from urllib.request import Request, urlopen
 
 TARGET_TO_SUFFIX = {
@@ -28,6 +28,40 @@ TARGET_TO_SUFFIX = {
 }
 
 NPM_REGISTRY_URL = "https://registry.npmjs.org"
+
+
+def _resolve_network_timeout_seconds() -> float:
+    """Resolve timeout for network requests, defaulting to 30 seconds."""
+    raw = os.environ.get("CODEX_SETUP_NETWORK_TIMEOUT_SECONDS", "30").strip()
+    try:
+        timeout = float(raw)
+    except ValueError:
+        print(
+            "WARNING: Invalid CODEX_SETUP_NETWORK_TIMEOUT_SECONDS="
+            f"{raw!r}; falling back to 30."
+        )
+        return 30.0
+    if timeout <= 0:
+        print(
+            "WARNING: CODEX_SETUP_NETWORK_TIMEOUT_SECONDS must be > 0; "
+            "falling back to 30."
+        )
+        return 30.0
+    return timeout
+
+
+NETWORK_TIMEOUT_SECONDS = _resolve_network_timeout_seconds()
+
+
+def _validate_https_url(url: str, *, source: str) -> None:
+    """Ensure URL uses https and includes a host."""
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme != "https" or not parsed.netloc:
+        raise RuntimeError(
+            f"Refusing {source} from unsupported URL {url!r}. "
+            "Only absolute https URLs are allowed."
+        )
 
 
 def get_transport() -> str:
@@ -45,16 +79,27 @@ def get_transport() -> str:
 def _registry_json(path: str) -> dict:
     """Fetch and decode JSON from the npm registry."""
     url = f"{NPM_REGISTRY_URL}/{path.lstrip('/')}"
+    _validate_https_url(url, source="registry metadata request")
     request = Request(url, headers={"Accept": "application/json"})
-    with urlopen(request) as response:
-        return json.loads(response.read().decode("utf-8"))
+    try:
+        with urlopen(request, timeout=NETWORK_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError:
+        raise
+    except URLError as exc:
+        raise RuntimeError(f"Failed to fetch registry metadata from {url}") from exc
 
 
 def _download_file(url: str, destination: Path) -> None:
     """Download a URL to a destination path."""
+    _validate_https_url(url, source="file download")
     request = Request(url)
-    with urlopen(request) as response, destination.open("wb") as handle:
-        shutil.copyfileobj(response, handle)
+    try:
+        with urlopen(request, timeout=NETWORK_TIMEOUT_SECONDS) as response:
+            with destination.open("wb") as handle:
+                shutil.copyfileobj(response, handle)
+    except URLError as exc:
+        raise RuntimeError(f"Failed to download file from {url}") from exc
 
 
 def _download_tarball_from_registry(
@@ -154,7 +199,9 @@ def resolve_codex_version(transport: str) -> str:
     latest = _registry_json(f"{quote('@openai/codex', safe='')}/latest")
     version = latest.get("version", "").strip()
     if not version:
-        raise RuntimeError("Could not resolve @openai/codex latest version from registry")
+        raise RuntimeError(
+            "Could not resolve @openai/codex latest version from registry"
+        )
     print(f"Resolved @openai/codex version: {version}")
     return version
 

--- a/src/codex_sdk/__init__.py
+++ b/src/codex_sdk/__init__.py
@@ -79,7 +79,7 @@ from .thread import (
     Turn,
 )
 
-__version__ = "0.104.1"
+__version__ = "0.105.0"
 
 __all__ = [
     "AbortController",

--- a/uv.lock
+++ b/uv.lock
@@ -416,7 +416,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath", marker = "python_full_version >= '3.10'" },
     { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
-    { name = "urllib3", marker = "python_full_version >= '3.10'" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/b5/8f961c65898deb5417c9e9e908ea6c4d2fe8bb52ff04e552f679c88ed2ce/botocore-1.42.25.tar.gz", hash = "sha256:7ae79d1f77d3771e83e4dd46bce43166a1ba85d58a49cffe4c4a721418616054", size = 14879737, upload-time = "2026-01-09T20:27:34.676Z" }
 wheels = [
@@ -680,7 +680,7 @@ wheels = [
 
 [[package]]
 name = "codex-sdk-python"
-version = "0.104.1"
+version = "0.105.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -752,7 +752,7 @@ dependencies = [
     { name = "httpx", marker = "python_full_version >= '3.10'" },
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "requests", marker = "python_full_version >= '3.10'" },
     { name = "tokenizers", marker = "python_full_version >= '3.10'" },
     { name = "types-requests", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1494,7 +1494,7 @@ wheels = [
 
 [package.optional-dependencies]
 requests = [
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "requests", marker = "python_full_version >= '3.10'" },
 ]
 
 [[package]]
@@ -1507,7 +1507,7 @@ dependencies = [
     { name = "google-auth", extra = ["requests"], marker = "python_full_version >= '3.10'" },
     { name = "httpx", marker = "python_full_version >= '3.10'" },
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "requests", marker = "python_full_version >= '3.10'" },
     { name = "sniffio", marker = "python_full_version >= '3.10'" },
     { name = "tenacity", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1644,7 +1644,7 @@ dependencies = [
     { name = "hf-xet", marker = "(python_full_version >= '3.10' and platform_machine == 'aarch64') or (python_full_version >= '3.10' and platform_machine == 'amd64') or (python_full_version >= '3.10' and platform_machine == 'arm64') or (python_full_version >= '3.10' and platform_machine == 'x86_64')" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "requests", marker = "python_full_version >= '3.10'" },
     { name = "tqdm", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -2537,7 +2537,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-common", version = "1.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "opentelemetry-proto", version = "1.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "opentelemetry-sdk", version = "1.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "requests", version = "2.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "requests", marker = "python_full_version < '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/48/e4314ac0ed2ad043c07693d08c9c4bf5633857f5b72f2fefc64fd2b114f6/opentelemetry_exporter_otlp_proto_http-1.33.1.tar.gz", hash = "sha256:46622d964a441acb46f463ebdc26929d9dec9efb2e54ef06acdc7305e8593c38", size = 15353, upload-time = "2025-05-16T18:52:45.522Z" }
 wheels = [
@@ -2558,7 +2558,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-common", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "opentelemetry-proto", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "opentelemetry-sdk", version = "1.39.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "requests", marker = "python_full_version >= '3.9'" },
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
@@ -3148,7 +3148,7 @@ temporal = [
 ]
 vertexai = [
     { name = "google-auth", marker = "python_full_version >= '3.10'" },
-    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "requests", marker = "python_full_version >= '3.10'" },
 ]
 
 [[package]]
@@ -3828,30 +3828,14 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.15.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
-    "python_full_version < '3.8.1'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/ed/3adebdc29ca33f11bca00c38c72125cd4a51091e13685375ba4426fb59dc/requests-2.15.1.tar.gz", hash = "sha256:e5659b9315a0610505e050bb7190bf6fa2ccee1ac295f2b760ef9d8a03ebbb2e", size = 548172, upload-time = "2017-05-27T02:14:22.414Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/a5/e04c4607dc96e3e6b22dfa13ba8776c64bb65cb97ab90f05a3ee14096a0a/requests-2.15.1-py2.py3-none-any.whl", hash = "sha256:ff753b2196cd18b1bbeddc9dcd5c864056599f7a7d9a4fb5677e723efa2b7fb9", size = 558730, upload-time = "2017-05-27T02:14:19.048Z" },
-]
-
-[[package]]
-name = "requests"
 version = "2.32.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version == '3.9.*'",
-]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.9'" },
-    { name = "charset-normalizer", marker = "python_full_version >= '3.9'" },
-    { name = "idna", marker = "python_full_version >= '3.9'" },
-    { name = "urllib3", marker = "python_full_version >= '3.9'" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
 wheels = [
@@ -4199,7 +4183,7 @@ name = "types-requests"
 version = "2.32.4.20260107"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "urllib3", marker = "python_full_version >= '3.10'" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165, upload-time = "2026-01-07T03:20:54.091Z" }
 wheels = [
@@ -4246,8 +4230,25 @@ wheels = [
 
 [[package]]
 name = "urllib3"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
+]
+
+[[package]]
+name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },


### PR DESCRIPTION
## Release 0.105.0 (validated against `v0.104.0`)

This PR is intended for the `0.105.0` release and is accurate to the full release delta.

## Scope clarity

### Net-new in this PR (`origin/main..codex/release-0.105.0`)
- `scripts/setup_binary.py`: default binary acquisition switched to **direct npm registry download** (no Node/npm required), with optional `CODEX_SETUP_TRANSPORT=npm` fallback.
- `ci.yml`: test job now runs `python scripts/setup_binary.py` before pytest.
- `README.md`: architecture/transport and streaming semantics documentation refresh.
- Version metadata bumped to `0.105.0` (`pyproject.toml`, `src/codex_sdk/__init__.py`, README badge).
- `CHANGELOG_SDK.md`, `AGENTS.md`, and `uv.lock` updated accordingly.

### Full release delta (`v0.104.0..HEAD`)
Includes everything above **plus** the already-merged `0.104.1` compatibility work present on `main`:
- PydanticAI stream compatibility update in `CodexModel.request_stream(...)` (optional `run_context`).
- Added `CodexStreamedResponse.provider_url` for newer pydantic-ai stream interfaces.
- Associated tests/examples for pydantic-ai run/run_stream compatibility.

## Important behavior statement (transport)

This release **does not** switch the SDK to app-server-only execution.

Current behavior remains:
- `Codex` / `Thread` APIs -> `codex exec --experimental-json`
- `AppServerClient` APIs -> `codex app-server` (JSON-RPC)
- `CodexModel` (PydanticAI provider) -> currently uses `Thread.run_json(...)` on top of `codex exec`

README changes clarify these transport boundaries; they do not change the runtime default path.

## Why this release

Primary goal: remove reliance on committed vendor binary churn for CI/release branches, while keeping binary setup deterministic and keeping docs aligned with actual implementation.

## Validation
- `uv run pytest`
  - Result: `235 passed`

## Reviewer notes
- Vendor binaries are intentionally not updated in this PR.
- CI now acquires Codex binaries at test time.

## Files changed in this PR
- `.github/workflows/ci.yml`
- `scripts/setup_binary.py`
- `README.md`
- `CHANGELOG_SDK.md`
- `pyproject.toml`
- `src/codex_sdk/__init__.py`
- `AGENTS.md`
- `uv.lock`

## Post-merge release steps
1. Merge this PR to `main`.
2. Create/push tag `v0.105.0`.
3. Allow release + publish workflows to run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved binary setup process with flexible dependency resolution and configurable transport options for increased installation flexibility.

* **Documentation**
  * Extensively updated documentation covering execution surfaces, streaming semantics, app-server lifecycle, PydanticAI integrations, architectural components, new code examples, and CI/CD workflows.

* **Chores**
  * Version bumped to 0.105.0 with updated build constraints and enhanced continuous integration initialization steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->