### PR TITLE
CodexModel: app-server-only provider path with incremental streaming

### DIFF
--- a/CHANGELOG_SDK.md
+++ b/CHANGELOG_SDK.md
@@ -4,6 +4,21 @@ This file tracks SDK-level changes. Keep the newest changes at the top.
 
 ## [Unreleased]
 
+### Breaking
+- `CodexModel` is now app-server-only for PydanticAI model-provider requests.
+- Removed the legacy `CodexModel(codex=...)` fallback execution path.
+
+### Added
+- `CodexModel.close()` to release owned app-server resources explicitly.
+- `CodexModel.performance_profile` (`"balanced"` or `"max"`).
+- `CodexModel.thread_reuse_mode` (`"run"` or `"always"`).
+
+### Fixed
+- `CodexModel.request_stream(...)` now emits incremental stream events during
+  app-server turn processing.
+- Stream compatibility for both legacy and newer PydanticAI
+  `handle_text_delta(...)` return styles.
+
 ## [0.105.0] - 2026-02-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ python examples/pydantic_ai_run_stream_compat.py
 | ------- | ----------------- | ----------- |
 | `Codex` + `Thread` | `codex exec --experimental-json` (JSONL over stdio) | Conversational turns, streaming item events, structured output (`run_json` / `run_pydantic`). |
 | `AppServerClient` | `codex app-server` (JSON-RPC over stdio) | Full app-server protocol: thread management, turn sessions, approvals, account/config/skills APIs. |
-| `CodexModel` (PydanticAI provider) | `Thread.run_json(...)` on top of `codex exec` | Tool-call planning + optional final text via strict JSON envelope. |
+| `CodexModel` (PydanticAI provider) | `codex app-server` (JSON-RPC over stdio) | Tool-call planning + text generation through app-server turn sessions with incremental stream events. |
 | `codex_handoff_tool` (PydanticAI tool) | `Thread.run(...)` on top of `codex exec` | Delegate repository-aware tasks from another model to Codex. |
 
 <a id="configuration"></a>
@@ -641,6 +641,9 @@ Additional controls:
 
 This SDK offers two ways to integrate with PydanticAI:
 
+Note: starting in `0.105.0`, `CodexModel` is app-server-only and no longer supports
+the legacy `CodexModel(codex=...)` fallback path.
+
 ### 1) Codex as a PydanticAI model provider
 
 Use `CodexModel` to delegate tool-call planning and text generation to Codex, while PydanticAI executes tools and validates outputs.
@@ -668,12 +671,20 @@ print(result.output)
 ```
 
 How it works:
+- `CodexModel` keeps a persistent app-server session and starts/reuses threads based on
+  `thread_reuse_mode` (`"run"` by default, `"always"` optional).
 - `CodexModel` builds a JSON schema envelope with `tool_calls` and `final`.
 - Codex emits tool calls as JSON strings; PydanticAI runs them.
 - If `allow_text_output` is true, Codex can place final text in `final`.
-- Streaming APIs (`Agent.run_stream(...)`, `Agent.run_stream_events()`, `Agent.run_stream_sync()`)
-  are supported for compatibility; response parts are emitted after the underlying `run_json(...)`
-  turn completes (not token-by-token from Codex).
+- Streaming APIs emit incremental events while app-server turn notifications arrive.
+
+Provider options:
+- `performance_profile`: `"balanced"` (default) or `"max"`.
+- `thread_reuse_mode`: `"run"` (default) or `"always"`.
+
+Lifecycle:
+- `CodexModel` owns an app-server client by default; call `await model.close()` in
+  long-lived processes to release resources.
 
 Safety defaults (you can override with your own `ThreadOptions`):
 - `sandbox_mode="read-only"`
@@ -746,7 +757,8 @@ flowchart LR
     U[User Code]
     T[Codex + Thread API]
     A[AppServerClient API]
-    M[PydanticAI Integrations]
+    PM[PydanticAI CodexModel]
+    PH[PydanticAI codex_handoff_tool]
   end
 
   subgraph SDK[Codex SDK]
@@ -766,10 +778,11 @@ flowchart LR
 
   U --> T --> C --> E --> X
   U --> A --> R --> S
-  U --> M
-  M --> C
+  U --> PM --> R
+  U --> PH --> C
   X -->|JSONL events| P --> T
   S -->|JSON-RPC messages| R --> A
+  S -->|JSON-RPC messages| R --> PM
   X --> FS
   X --> NET
   S --> FS
@@ -827,15 +840,13 @@ sequenceDiagram
 sequenceDiagram
   participant Agent as PydanticAI Agent
   participant Model as CodexModel
-  participant SDK as Codex SDK
-  participant CLI as codex exec
+  participant App as Codex app-server
   participant Tools as User Tools
 
   Agent->>Model: request(messages, tools)
-  Model->>SDK: start_thread + run_json(prompt, output_schema)
-  SDK->>CLI: codex exec --output-schema
-  CLI-->>SDK: JSON envelope {tool_calls, final}
-  SDK-->>Model: ParsedTurn
+  Model->>App: thread/start (if needed)
+  Model->>App: turn/session(input + output_schema envelope)
+  App-->>Model: item/updated + turn/completed notifications
   alt tool_calls present
     Model-->>Agent: ToolCallPart(s)
     Agent->>Tools: execute tool(s)
@@ -861,7 +872,7 @@ flowchart LR
 
 - `Thread.run_streamed()` and `Thread.run_streamed_events()` stream incremental `ThreadEvent` values as JSONL lines arrive from `codex exec`.
 - `AppServerClient.notifications()` streams incremental JSON-RPC notifications from `codex app-server`.
-- `CodexModel.request_stream(...)` exposes a stream-compatible interface for PydanticAI, but events are emitted from an already-completed `run_json(...)` result.
+- `CodexModel.request_stream(...)` emits incremental events from app-server turn notifications, with compatibility handling for current and legacy PydanticAI stream interfaces.
 
 <a id="testing"></a>
 ## ![Testing](https://img.shields.io/badge/Testing-Pytest%20%26%20Coverage-2563eb?style=for-the-badge&logo=pytest&logoColor=white)

--- a/examples/pydantic_ai_model_provider.py
+++ b/examples/pydantic_ai_model_provider.py
@@ -2,7 +2,7 @@
 Example: use Codex as a PydanticAI model provider.
 
 This lets PydanticAI manage tools + validation, while Codex generates tool-call
-plans and final responses via `codex exec --output-schema`.
+plans and final responses through the app-server-backed CodexModel runtime.
 
 Requires:
   uv add "codex-sdk-python[pydantic-ai]"

--- a/examples/pydantic_ai_run_compat.py
+++ b/examples/pydantic_ai_run_compat.py
@@ -1,96 +1,60 @@
-"""Minimal harness for non-stream Agent.run parity with CodexModel."""
+"""Minimal harness for non-stream Agent.run parity with app-server CodexModel."""
 
 import asyncio
-import json
-import re
 
 from pydantic_ai import Agent
 
-from codex_sdk.events import Usage
+from codex_sdk.app_server import AppServerNotification
 from codex_sdk.integrations.pydantic_ai_model import CodexModel
-from codex_sdk.thread import ParsedTurn, Turn
 
 
-class _FakeThread:
-    def __init__(self) -> None:
-        self.id = "thread-compat-run"
+class _FakeAppServerTurnSession:
+    def __init__(self, notifications, final_turn):
+        self._notifications = list(notifications)
+        self._final_turn = dict(final_turn)
 
-    async def run_json(self, prompt, *, output_schema, turn_options=None):
-        tool_names = (
-            output_schema.get("properties", {})
-            .get("tool_calls", {})
-            .get("items", {})
-            .get("properties", {})
-            .get("name", {})
-            .get("enum", [])
+    async def notifications(self):
+        for notification in self._notifications:
+            yield notification
+
+    async def wait(self):
+        return self._final_turn
+
+
+class _FakeAppServerClient:
+    async def start(self):
+        return None
+
+    async def close(self):
+        return None
+
+    async def thread_start(self, **_params):
+        return {"thread": {"id": "thread-compat-run"}}
+
+    async def turn_session(self, _thread_id, _input, **_params):
+        return _FakeAppServerTurnSession(
+            notifications=[
+                AppServerNotification(
+                    method="item/updated",
+                    params={
+                        "item": {
+                            "id": "msg-1",
+                            "type": "agent_message",
+                            "text": "run ok",
+                        }
+                    },
+                )
+            ],
+            final_turn={
+                "id": "turn-compat-run",
+                "usage": {"inputTokens": 1, "outputTokens": 1},
+                "finalResponse": "run ok",
+            },
         )
-        output = {"tool_calls": [], "final": "run ok"}
-        if tool_names:
-            first_tool = tool_names[0]
-            args_json = _build_args_json(prompt, first_tool)
-            output = {
-                "tool_calls": [
-                    {"id": "call_1", "name": first_tool, "arguments": args_json}
-                ],
-                "final": "",
-            }
-        turn = Turn(
-            items=[],
-            final_response="",
-            usage=Usage(input_tokens=1, cached_input_tokens=0, output_tokens=1),
-        )
-        return ParsedTurn(turn=turn, output=output)
-
-
-class _FakeCodex:
-    def __init__(self) -> None:
-        self._thread = _FakeThread()
-
-    def start_thread(self, options=None):
-        return self._thread
-
-
-def _build_args_json(prompt: str, tool_name: str) -> str:
-    pattern = re.compile(
-        rf"- {re.escape(tool_name)}\\n(?:  .*\\n)*?  parameters_json_schema: (.+)"
-    )
-    match = pattern.search(prompt)
-    if not match:
-        return "{}"
-    try:
-        schema = json.loads(match.group(1))
-    except json.JSONDecodeError:
-        return "{}"
-    value = _example_value(schema)
-    if isinstance(value, dict):
-        return json.dumps(value, separators=(",", ":"))
-    return "{}"
-
-
-def _example_value(schema):
-    schema_type = schema.get("type")
-    if schema_type == "object":
-        properties = schema.get("properties", {})
-        required = schema.get("required", [])
-        result = {}
-        keys = required or list(properties.keys())[:1]
-        for key in keys:
-            child_schema = properties.get(key, {"type": "string"})
-            result[key] = _example_value(child_schema)
-        return result
-    if schema_type == "array":
-        return []
-    if schema_type == "integer":
-        return 1
-    if schema_type == "number":
-        return 1.0
-    if schema_type == "boolean":
-        return True
-    return "ok"
 
 
 async def _main() -> None:
-    agent = Agent(model=CodexModel(codex=_FakeCodex()), output_type=str)
+    agent = Agent(model=CodexModel(app_server=_FakeAppServerClient()), output_type=str)
     result = await agent.run("ping")
     assert result.output == "run ok"
     print("run compatible:", result.output)

--- a/examples/pydantic_ai_run_stream_compat.py
+++ b/examples/pydantic_ai_run_stream_compat.py
@@ -1,108 +1,79 @@
-"""Minimal harness reproducing Agent.run_stream + CodexModel compatibility."""
+"""Minimal harness reproducing Agent.run_stream + app-server CodexModel compatibility."""
 
 import asyncio
-import json
-import re
 
 from pydantic_ai import Agent
 
-from codex_sdk.events import Usage
+from codex_sdk.app_server import AppServerNotification
 from codex_sdk.integrations.pydantic_ai_model import CodexModel
-from codex_sdk.thread import ParsedTurn, Turn
 
 
-class _FakeThread:
-    def __init__(self) -> None:
-        self.id = "thread-compat-stream"
+class _FakeAppServerTurnSession:
+    def __init__(self, notifications, final_turn):
+        self._notifications = list(notifications)
+        self._final_turn = dict(final_turn)
 
-    async def run_json(self, prompt, *, output_schema, turn_options=None):
-        tool_names = (
-            output_schema.get("properties", {})
-            .get("tool_calls", {})
-            .get("items", {})
-            .get("properties", {})
-            .get("name", {})
-            .get("enum", [])
+    async def notifications(self):
+        for notification in self._notifications:
+            yield notification
+
+    async def wait(self):
+        return self._final_turn
+
+
+class _FakeAppServerClient:
+    async def start(self):
+        return None
+
+    async def close(self):
+        return None
+
+    async def thread_start(self, **_params):
+        return {"thread": {"id": "thread-compat-stream"}}
+
+    async def turn_session(self, _thread_id, _input, **_params):
+        return _FakeAppServerTurnSession(
+            notifications=[
+                AppServerNotification(
+                    method="item/updated",
+                    params={
+                        "item": {
+                            "id": "msg-1",
+                            "type": "agent_message",
+                            "text": "stream ",
+                        }
+                    },
+                ),
+                AppServerNotification(
+                    method="item/updated",
+                    params={
+                        "item": {
+                            "id": "msg-1",
+                            "type": "agent_message",
+                            "text": "stream ok",
+                        }
+                    },
+                ),
+            ],
+            final_turn={
+                "id": "turn-compat-stream",
+                "usage": {"inputTokens": 1, "outputTokens": 1},
+                "finalResponse": "stream ok",
+            },
         )
-        output = {"tool_calls": [], "final": "stream ok"}
-        if tool_names:
-            first_tool = tool_names[0]
-            args_json = _build_args_json(prompt, first_tool)
-            output = {
-                "tool_calls": [
-                    {"id": "call_1", "name": first_tool, "arguments": args_json}
-                ],
-                "final": "",
-            }
-        turn = Turn(
-            items=[],
-            final_response="",
-            usage=Usage(input_tokens=1, cached_input_tokens=0, output_tokens=1),
-        )
-        return ParsedTurn(turn=turn, output=output)
-
-
-class _FakeCodex:
-    def __init__(self) -> None:
-        self._thread = _FakeThread()
-
-    def start_thread(self, options=None):
-        return self._thread
-
-
-def _build_args_json(prompt: str, tool_name: str) -> str:
-    pattern = re.compile(
-        rf"- {re.escape(tool_name)}\\n(?:  .*\\n)*?  parameters_json_schema: (.+)"
-    )
-    match = pattern.search(prompt)
-    if not match:
-        return "{}"
-    try:
-        schema = json.loads(match.group(1))
-    except json.JSONDecodeError:
-        return "{}"
-    value = _example_value(schema)
-    if isinstance(value, dict):
-        return json.dumps(value, separators=(",", ":"))
-    return "{}"
-
-
-def _example_value(schema):
-    schema_type = schema.get("type")
-    if schema_type == "object":
-        properties = schema.get("properties", {})
-        required = schema.get("required", [])
-        result = {}
-        keys = required or list(properties.keys())[:1]
-        for key in keys:
-            child_schema = properties.get(key, {"type": "string"})
-            result[key] = _example_value(child_schema)
-        return result
-    if schema_type == "array":
-        return []
-    if schema_type == "integer":
-        return 1
-    if schema_type == "number":
-        return 1.0
-    if schema_type == "boolean":
-        return True
-    return "ok"
 
 
 async def _main() -> None:
-    agent = Agent(model=CodexModel(codex=_FakeCodex()), output_type=str)
+    agent = Agent(model=CodexModel(app_server=_FakeAppServerClient()), output_type=str)
     try:
         async with agent.run_stream("ping") as result:
             output = await result.get_output()
-    except TypeError as exc:
-        raise AssertionError(f"run_stream raised TypeError: {exc}") from exc
     except Exception as exc:
-        print(
-            "run_stream invoked without TypeError "
-            f"(raised {type(exc).__name__}: {exc})"
-        )
-        return
+        raise AssertionError(
+            f"run_stream failed with {type(exc).__name__}: {exc}"
+        ) from exc
 
+    assert output == "stream ok"
     print("run_stream compatible:", output)
 
 

--- a/src/codex_sdk/integrations/pydantic_ai_model.py
+++ b/src/codex_sdk/integrations/pydantic_ai_model.py
@@ -1217,6 +1217,7 @@ class CodexModel(Model):
             task = asyncio.create_task(_runner())
             try:
                 yield streamed
+                # Ensure completion and propagate any exception from the runner task.
                 await task
             finally:
                 if not task.done():

--- a/src/codex_sdk/integrations/pydantic_ai_model.py
+++ b/src/codex_sdk/integrations/pydantic_ai_model.py
@@ -1,10 +1,10 @@
-"""PydanticAI model-provider integration.
+"""PydanticAI model-provider integration backed by Codex app-server.
 
 This module provides a `pydantic_ai.models.Model` implementation that delegates
-completion + tool-call planning to Codex via `codex exec --output-schema`.
+completion + tool-call planning to Codex via a persistent app-server session.
 
 The goal is to let PydanticAI own the tool loop (tool execution, retries, output
-validation), while Codex behaves like a "backend model" that emits either:
+validation), while Codex behaves like a backend model that emits either:
 
 - tool calls (to be executed by PydanticAI), or
 - a final text response (when text output is allowed).
@@ -12,18 +12,20 @@ validation), while Codex behaves like a "backend model" that emits either:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from base64 import b64encode
 from contextlib import asynccontextmanager
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import asdict, dataclass, field, is_dataclass
 from datetime import datetime, timezone
-from typing import Any, AsyncIterator, Dict, List, Optional, Sequence
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, Iterator, List, Mapping, Optional, Sequence
 
-from ..codex import Codex
+from ..app_server import AppServerClient, AppServerNotification, AppServerOptions
+from ..exceptions import CodexError, TurnFailedError
 from ..options import CodexOptions, ThreadOptions
 from ..telemetry import span
-from ..thread import TurnOptions
 
 try:
     from pydantic_ai.messages import (
@@ -51,22 +53,55 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class _ToolCallEnvelope:
-    """Parsed tool-call envelope returned by Codex `--output-schema` turns."""
+    """Parsed tool-call envelope returned by Codex turns."""
 
     tool_call_id: str
     tool_name: str
     arguments_json: str
 
 
+@dataclass(frozen=True)
+class _TextDeltaInstruction:
+    """Instruction for streamed text-delta emission."""
+
+    vendor_part_id: Any
+    content: str
+
+
+@dataclass(frozen=True)
+class _ToolCallInstruction:
+    """Instruction for streamed tool-call emission."""
+
+    vendor_part_id: Any
+    tool_name: str
+    args: Any
+    tool_call_id: Optional[str]
+
+
+@dataclass
+class _TurnAccumulationState:
+    """State accumulated while consuming app-server notifications for a turn."""
+
+    latest_agent_text: str = ""
+    item_text_by_id: Dict[str, str] = field(default_factory=dict)
+    last_updated_item_id: Optional[str] = None
+    vendor_part_ids: Dict[str, int] = field(default_factory=dict)
+    next_vendor_part_id: int = 0
+    usage: Optional[RequestUsage] = None
+    turn_failed_message: Optional[str] = None
+
+
 def _jsonable(value: Any) -> Any:
     """Convert values into JSON-serializable structures for prompt/debug output."""
+    if isinstance(value, Path):
+        return str(value)
     if is_dataclass(value) and not isinstance(value, type):
         return asdict(value)
     if hasattr(value, "model_dump") and callable(getattr(value, "model_dump")):
         return value.model_dump(mode="json")
     if isinstance(value, bytes):
         return {"type": "bytes", "base64": b64encode(value).decode("ascii")}
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         return {str(k): _jsonable(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_jsonable(v) for v in value]
@@ -117,19 +152,7 @@ def _render_tool_definitions(
     function_tools: Sequence[ToolDefinition],
     output_tools: Sequence[ToolDefinition],
 ) -> str:
-    """
-    Render a human-readable description of provided function and output tool definitions for inclusion in prompts.
-
-    Produces a newline-separated block that lists each tool with name, optional description, kind, parameters JSON schema, and optional fields such as outer_typed_dict_key, strict, sequential, metadata, and timeout. Function tools are listed under "Function tools:" and output tools under "Output tools (use ONE of these to finish when text is not allowed):".
-
-    Args:
-        function_tools: Tool definitions intended to be called as functions.
-        output_tools: Tool definitions intended as final output options when direct text
-            is disallowed.
-
-    Returns:
-        The rendered, trimmed multi-line string describing the tools.
-    """
+    """Render tool definitions into prompt text."""
     lines: List[str] = []
     lines.extend(_render_tool_section("Function tools:", function_tools))
     if output_tools:
@@ -141,7 +164,6 @@ def _render_tool_definitions(
                 output_tools,
             )
         )
-
     return "\n".join(lines).strip()
 
 
@@ -175,7 +197,7 @@ def _render_tool_section(title: str, tools: Sequence[ToolDefinition]) -> List[st
 
 
 def _tool_calls_from_envelope(output: Any) -> List[_ToolCallEnvelope]:
-    """Extract tool call envelopes from a Codex JSON turn output."""
+    """Extract tool call envelopes from an envelope object."""
     if not isinstance(output, dict):
         return []
 
@@ -207,7 +229,7 @@ def _tool_calls_from_envelope(output: Any) -> List[_ToolCallEnvelope]:
 
 
 def _final_from_envelope(output: Any) -> str:
-    """Extract the final text from a Codex JSON turn output."""
+    """Extract the final text from an envelope object."""
     if not isinstance(output, dict):
         return ""
     final = output.get("final")
@@ -256,7 +278,6 @@ def _render_message_history(messages: Sequence[ModelMessage]) -> str:
                     lines.append("[request-part]")
                     lines.append(_json_dumps(part))
         else:
-            # ModelResponse
             lines.append("[assistant]")
             for part in message.parts:
                 part_kind = getattr(part, "part_kind", None)
@@ -271,7 +292,6 @@ def _render_message_history(messages: Sequence[ModelMessage]) -> str:
                         f"[tool-call:{tool_name} id={tool_call_id}] {args_json}"
                     )
                 elif part_kind == "thinking":
-                    # Intentionally omit to reduce prompt noise.
                     pass
                 else:
                     lines.append(f"[assistant-part:{part_kind}]")
@@ -284,8 +304,178 @@ def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _extract_json_object(text: str) -> Optional[Any]:
+    """Best-effort parse of a JSON object from model text output."""
+    stripped = text.strip()
+    if not stripped:
+        return None
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        start = stripped.find("{")
+        end = stripped.rfind("}")
+        if start < 0 or end <= start:
+            return None
+        fragment = stripped[start : end + 1]
+        try:
+            return json.loads(fragment)
+        except json.JSONDecodeError:
+            return None
+
+
+def _is_envelope_candidate(value: Any) -> bool:
+    """Return whether a decoded JSON object looks like the envelope shape."""
+    return isinstance(value, dict) and ("tool_calls" in value or "final" in value)
+
+
+def _to_int(value: Any) -> int:
+    """Best-effort int conversion for usage fields."""
+    try:
+        if value is None:
+            return 0
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _usage_from_mapping(raw: Any) -> Optional[RequestUsage]:
+    """Parse a RequestUsage from a raw mapping payload."""
+    if not isinstance(raw, Mapping):
+        return None
+
+    input_tokens = _to_int(raw.get("inputTokens", raw.get("input_tokens")))
+    cached_input_tokens = _to_int(
+        raw.get("cachedInputTokens", raw.get("cached_input_tokens"))
+    )
+    output_tokens = _to_int(raw.get("outputTokens", raw.get("output_tokens")))
+    details = (
+        {"cached_input_tokens": cached_input_tokens} if cached_input_tokens else {}
+    )
+    return RequestUsage(
+        input_tokens=input_tokens,
+        cache_read_tokens=cached_input_tokens,
+        output_tokens=output_tokens,
+        details=details,
+    )
+
+
+def _notification_items(notification: AppServerNotification) -> List[Dict[str, Any]]:
+    """Extract item payloads from a notification payload (best effort)."""
+    params = notification.params
+    if not isinstance(params, Mapping):
+        return []
+
+    items: List[Dict[str, Any]] = []
+    item = params.get("item")
+    if isinstance(item, Mapping):
+        items.append(dict(item))
+
+    raw_items = params.get("items")
+    if isinstance(raw_items, list):
+        for raw in raw_items:
+            if isinstance(raw, Mapping):
+                items.append(dict(raw))
+
+    turn = params.get("turn")
+    if isinstance(turn, Mapping):
+        turn_item = turn.get("item")
+        if isinstance(turn_item, Mapping):
+            items.append(dict(turn_item))
+        turn_items = turn.get("items")
+        if isinstance(turn_items, list):
+            for raw in turn_items:
+                if isinstance(raw, Mapping):
+                    items.append(dict(raw))
+
+    return items
+
+
+def _extract_agent_text_from_item(item: Mapping[str, Any]) -> Optional[str]:
+    """Extract agent text from a normalized item mapping."""
+    item_type = item.get("type")
+    if item_type not in {"agent_message", "agentMessage"}:
+        return None
+    text = item.get("text")
+    if isinstance(text, str):
+        return text
+    content = item.get("content")
+    if isinstance(content, str):
+        return content
+    return None
+
+
+def _extract_usage_from_turn(
+    turn: Optional[Mapping[str, Any]],
+) -> Optional[RequestUsage]:
+    """Extract usage metadata from a turn payload (best effort)."""
+    if not isinstance(turn, Mapping):
+        return None
+    usage = _usage_from_mapping(turn.get("usage"))
+    if usage is not None:
+        return usage
+    return _usage_from_mapping(turn.get("tokenUsage"))
+
+
+def _extract_turn_text(turn: Optional[Mapping[str, Any]]) -> str:
+    """Extract final text from a turn payload (best effort)."""
+    if not isinstance(turn, Mapping):
+        return ""
+
+    text_keys = [
+        "finalResponse",
+        "final_response",
+        "outputText",
+        "output_text",
+        "text",
+        "output",
+        "response",
+    ]
+    for key in text_keys:
+        value = turn.get(key)
+        if isinstance(value, str):
+            return value
+
+    output = turn.get("output")
+    if isinstance(output, Mapping):
+        for key in ("text", "final", "response"):
+            value = output.get(key)
+            if isinstance(value, str):
+                return value
+
+    items = turn.get("items")
+    if isinstance(items, list):
+        for raw in reversed(items):
+            if not isinstance(raw, Mapping):
+                continue
+            text = _extract_agent_text_from_item(raw)
+            if text:
+                return text
+
+    return ""
+
+
+def _extract_turn_failure_message(notification: AppServerNotification) -> Optional[str]:
+    """Extract a failure message from turn failure notifications."""
+    if notification.method != "turn/failed":
+        return None
+    params = notification.params
+    if not isinstance(params, Mapping):
+        return "Turn failed"
+    error = params.get("error")
+    if isinstance(error, Mapping):
+        message = error.get("message")
+        if isinstance(message, str) and message:
+            return message
+    message = params.get("message")
+    if isinstance(message, str) and message:
+        return message
+    return "Turn failed"
+
+
 class CodexStreamedResponse(StreamedResponse):
-    """Minimal streamed response wrapper for Codex model provider."""
+    """Incremental streamed response wrapper for app-server-backed CodexModel."""
+
+    _STREAM_END = object()
 
     def __init__(
         self,
@@ -293,102 +483,179 @@ class CodexStreamedResponse(StreamedResponse):
         model_request_parameters: ModelRequestParameters,
         model_name: str,
         provider_name: Optional[str],
-        parts: Sequence[Any],
-        thread_id: str,
-        usage: RequestUsage,
+        parts: Optional[Sequence[Any]] = None,
+        thread_id: Optional[str] = None,
+        usage: Optional[RequestUsage] = None,
     ) -> None:
-        """Create a streamed response wrapper around precomputed Codex output.
+        """Create a streamed response wrapper.
 
         Args:
-            model_request_parameters: The request parameters used for the call.
-            model_name: The model identifier reported to PydanticAI.
-            provider_name: Optional provider/system identifier (e.g. "openai").
-            parts: Collected response parts (text/tool-call parts).
-            thread_id: Codex thread identifier for debugging/traceability.
-            usage: Request usage totals for the response.
+            model_request_parameters: PydanticAI request parameters for this response.
+            model_name: Model identifier to expose to PydanticAI.
+            provider_name: Provider/system identifier for metadata.
+            parts: Optional precomputed parts for compatibility with non-incremental
+                stream construction.
+            thread_id: Optional Codex thread identifier for provider details.
+            usage: Optional request usage snapshot.
         """
-        # `StreamedResponse` requires model_request_parameters and owns the parts manager.
         super().__init__(model_request_parameters=model_request_parameters)
         self._model_name = model_name
         self._provider_name = provider_name
-        self._parts = parts
         self._thread_id = thread_id
-        self._usage = usage
+        self._usage = usage or RequestUsage()
         self._timestamp = _now_utc()
+        self._instruction_queue: "asyncio.Queue[Any]" = asyncio.Queue()
+        self._stream_error: Optional[BaseException] = None
+        self._precomputed_parts: Optional[List[Any]] = list(parts) if parts else None
+
+    def push_text_delta(self, *, vendor_part_id: Any, content: str) -> None:
+        """Queue a text-delta instruction."""
+        self._instruction_queue.put_nowait(
+            _TextDeltaInstruction(vendor_part_id=vendor_part_id, content=content)
+        )
+
+    def push_tool_call(
+        self,
+        *,
+        vendor_part_id: Any,
+        tool_name: str,
+        args: Any,
+        tool_call_id: Optional[str],
+    ) -> None:
+        """Queue a tool-call instruction."""
+        self._instruction_queue.put_nowait(
+            _ToolCallInstruction(
+                vendor_part_id=vendor_part_id,
+                tool_name=tool_name,
+                args=args,
+                tool_call_id=tool_call_id,
+            )
+        )
+
+    def finish(
+        self,
+        *,
+        usage: Optional[RequestUsage] = None,
+        thread_id: Optional[str] = None,
+        error: Optional[BaseException] = None,
+    ) -> None:
+        """Mark the stream as complete and publish terminal metadata."""
+        if usage is not None:
+            self._usage = usage
+        if thread_id is not None:
+            self._thread_id = thread_id
+        if error is not None:
+            self._stream_error = error
+        self._instruction_queue.put_nowait(self._STREAM_END)
+
+    @staticmethod
+    def _iter_events(raw: Any) -> Iterator[ModelResponseStreamEvent]:
+        """Normalize parts-manager outputs to a stream of response events.
+
+        PydanticAI changed `handle_text_delta(...)` from returning a single event to
+        returning an iterator in newer releases. This helper supports both APIs.
+        """
+        if raw is None:
+            return
+        if hasattr(raw, "event_kind"):
+            yield raw
+            return
+        try:
+            iterator = iter(raw)
+        except TypeError:
+            logger.debug("Ignoring unexpected stream event payload: %r", raw)
+            return
+        for event in iterator:
+            if event is None:
+                continue
+            if hasattr(event, "event_kind"):
+                yield event
+            else:
+                logger.debug("Ignoring unknown stream event item: %r", event)
 
     async def _get_event_iterator(
         self,
     ) -> AsyncIterator[ModelResponseStreamEvent]:
-        """
-        Iterates over stored response parts and yields stream events for text deltas and tool-call parts.
+        """Yield stream events as queued instructions arrive."""
+        if self._precomputed_parts is not None:
+            parts = self._precomputed_parts
+            self._precomputed_parts = None
+            for index, part in enumerate(parts):
+                if isinstance(part, TextPart):
+                    events = self._parts_manager.handle_text_delta(
+                        vendor_part_id=index,
+                        content=part.content,
+                    )
+                elif isinstance(part, ToolCallPart):
+                    events = self._parts_manager.handle_tool_call_part(
+                        vendor_part_id=index,
+                        tool_name=part.tool_name,
+                        args=part.args,
+                        tool_call_id=part.tool_call_id,
+                    )
+                else:
+                    logger.debug(
+                        "Skipping unsupported streamed part",
+                        extra={
+                            "vendor_part_id": index,
+                            "part_type": type(part).__name__,
+                            "part_kind": getattr(part, "part_kind", None),
+                        },
+                    )
+                    events = None
+                for event in self._iter_events(events):
+                    yield event
+            if self._stream_error is not None:
+                raise self._stream_error
+            return
 
-        The iterator converts each TextPart into a text-delta event and each ToolCallPart into a tool-call event using the parts manager; other part kinds are ignored.
-
-        Returns:
-            ModelResponseStreamEvent: An event for each text or tool-call part, yielded in the original parts order.
-        """
-        for index, part in enumerate(self._parts):
-            if isinstance(part, TextPart):
-                event = self._parts_manager.handle_text_delta(
-                    vendor_part_id=index,
-                    content=part.content,
+        while True:
+            instruction = await self._instruction_queue.get()
+            if instruction is self._STREAM_END:
+                break
+            if isinstance(instruction, _TextDeltaInstruction):
+                events = self._parts_manager.handle_text_delta(
+                    vendor_part_id=instruction.vendor_part_id,
+                    content=instruction.content,
                 )
-            elif isinstance(part, ToolCallPart):
-                event = self._parts_manager.handle_tool_call_part(
-                    vendor_part_id=index,
-                    tool_name=part.tool_name,
-                    args=part.args,
-                    tool_call_id=part.tool_call_id,
+            elif isinstance(instruction, _ToolCallInstruction):
+                events = self._parts_manager.handle_tool_call_part(
+                    vendor_part_id=instruction.vendor_part_id,
+                    tool_name=instruction.tool_name,
+                    args=instruction.args,
+                    tool_call_id=instruction.tool_call_id,
                 )
             else:
-                logger.debug(
-                    "Skipping unsupported streamed part",
-                    extra={
-                        "vendor_part_id": index,
-                        "part_type": type(part).__name__,
-                        "part_kind": getattr(part, "part_kind", None),
-                    },
-                )
-                event = None
-
-            if event is not None:
+                logger.debug("Skipping unknown stream instruction: %r", instruction)
+                events = None
+            for event in self._iter_events(events):
                 yield event
 
-    def get(self) -> ModelResponse:
-        """
-        Construct a complete model response from events received so far.
+        if self._stream_error is not None:
+            raise self._stream_error
 
-        Returns:
-            ModelResponse: Contains collected parts, the model name, timestamp, usage,
-            and `provider_details` with the Codex thread_id.
-        """
+    def get(self) -> ModelResponse:
+        """Return a ModelResponse view over currently collected stream parts."""
+        provider_details: Dict[str, Any] = {}
+        if self._thread_id:
+            provider_details["thread_id"] = self._thread_id
         return ModelResponse(
             parts=self._parts_manager.get_parts(),
             model_name=self.model_name,
             provider_name=self.provider_name,
             timestamp=self.timestamp,
             usage=self.usage(),
-            provider_details={"thread_id": self._thread_id},
+            provider_details=provider_details,
         )
 
     @property
     def model_name(self) -> str:
-        """
-        Return the model identifier used for the response.
-
-        Returns:
-            The model identifier string.
-        """
+        """Return the model identifier used for the response."""
         return self._model_name
 
     @property
     def provider_name(self) -> Optional[str]:
-        """
-        Return the provider/system name for the response, if set.
-
-        PydanticAI models can optionally report a provider separate from the model name.
-        For Codex, this is typically the `system` identifier used for routing/metadata.
-        """
+        """Return the provider/system name for the response, if set."""
         return self._provider_name
 
     @property
@@ -398,72 +665,64 @@ class CodexStreamedResponse(StreamedResponse):
 
     @property
     def timestamp(self) -> datetime:
-        """
-        Get the UTC timestamp when this response was created.
-
-        Returns:
-            datetime: The timestamp associated with the response.
-        """
+        """Get the UTC timestamp when this response object was created."""
         return self._timestamp
 
 
 class CodexModel(Model):
-    """Use Codex CLI as a PydanticAI model provider via structured output.
-
-    Subclasses can override `prepare_request()` to mutate model settings and
-    request parameters before a Codex turn is executed.
-    """
+    """Use Codex app-server as a PydanticAI model provider."""
 
     def __init__(
         self,
         *,
-        codex: Optional[Codex] = None,
+        app_server: Optional[AppServerClient] = None,
+        app_server_options: Optional[AppServerOptions] = None,
         codex_options: Optional[CodexOptions] = None,
         thread_options: Optional[ThreadOptions] = None,
         profile: Optional[ModelProfileSpec] = None,
         settings: Optional[ModelSettings] = None,
         system: str = "openai",
+        performance_profile: str = "balanced",
+        thread_reuse_mode: str = "run",
     ) -> None:
-        """Create a Codex-backed PydanticAI model provider.
+        """Create an app-server-backed Codex model provider.
 
-        Args:
-            codex: Optional Codex instance to delegate work to.
-            codex_options: Options used only when creating a default Codex instance.
-            thread_options: Options used when starting Codex threads for each request.
-                When not provided, safe defaults are applied (read-only sandbox, no
-                web search, and no network).
-            profile: Optional PydanticAI profile describing capabilities.
-            settings: Optional PydanticAI model settings.
-            system: PydanticAI vendor/system identifier (used for routing/metadata).
+        The model defaults to app-server transport and run-scoped thread reuse.
         """
-        if codex is None:
-            codex = Codex(codex_options or CodexOptions())
-        if thread_options is None:
-            thread_options = ThreadOptions()
+        if performance_profile not in {"balanced", "max"}:
+            raise CodexError(
+                "performance_profile must be 'balanced' or 'max'; "
+                f"received {performance_profile!r}"
+            )
+        if thread_reuse_mode not in {"run", "always"}:
+            raise CodexError(
+                "thread_reuse_mode must be 'run' or 'always'; "
+                f"received {thread_reuse_mode!r}"
+            )
 
-        # As a model-provider wrapper, prefer safe + portable defaults.
-        if thread_options.skip_git_repo_check is None:
-            thread_options.skip_git_repo_check = True
-        if thread_options.sandbox_mode is None:
-            thread_options.sandbox_mode = "read-only"
-        if thread_options.approval_policy is None:
-            thread_options.approval_policy = "never"
-        if (
-            thread_options.web_search_mode is None
-            and thread_options.web_search_enabled is None
-            and thread_options.web_search_cached_enabled is None
-        ):
-            thread_options.web_search_mode = "disabled"
-        if thread_options.network_access_enabled is None:
-            thread_options.network_access_enabled = False
+        self._performance_profile = performance_profile
+        self._thread_reuse_mode = thread_reuse_mode
+        self._thread_options = self._prepare_thread_options(thread_options)
 
         if profile is None:
             profile = ModelProfile(supports_tools=True)
-
         super().__init__(settings=settings, profile=profile)
-        self._codex = codex
-        self._thread_options = thread_options
+
         self._system = system
+        self._request_lock = asyncio.Lock()
+        self._closed = False
+
+        self._app_client = app_server
+        self._owns_app_client = app_server is None
+        self._app_server_options: Optional[AppServerOptions] = (
+            self._resolve_app_server_options(
+                app_server_options=app_server_options,
+                codex_options=codex_options,
+            )
+        )
+
+        self._thread_id: Optional[str] = None
+        self._messages_seen = 0
 
     @property
     def model_name(self) -> str:
@@ -483,48 +742,200 @@ class CodexModel(Model):
         """Hook to customize request settings/parameters before execution."""
         return model_settings, model_request_parameters
 
-    async def _run_codex_request(
+    async def close(self) -> None:
+        """Close owned app-server resources and reset cached thread state."""
+        async with self._request_lock:
+            self._closed = True
+            try:
+                if self._owns_app_client and self._app_client is not None:
+                    await self._app_client.close()
+            finally:
+                self._app_client = None
+                self._thread_id = None
+                self._messages_seen = 0
+
+    async def _ensure_client(self) -> AppServerClient:
+        """Ensure an app-server client exists and is started."""
+        if self._closed:
+            raise CodexError("CodexModel is closed")
+        if self._app_server_options is None:
+            raise CodexError("App-server options are not configured")
+
+        if self._app_client is None:
+            self._app_client = AppServerClient(self._app_server_options)
+            self._owns_app_client = True
+
+        await self._app_client.start()
+        return self._app_client
+
+    def _prepare_thread_options(
+        self, thread_options: Optional[ThreadOptions]
+    ) -> ThreadOptions:
+        """Apply model-provider defaults to thread options."""
+        if thread_options is None:
+            thread_options = ThreadOptions()
+
+        if thread_options.skip_git_repo_check is None:
+            thread_options.skip_git_repo_check = True
+        if thread_options.sandbox_mode is None:
+            thread_options.sandbox_mode = "read-only"
+        if thread_options.approval_policy is None:
+            thread_options.approval_policy = "never"
+        if (
+            thread_options.web_search_mode is None
+            and thread_options.web_search_enabled is None
+            and thread_options.web_search_cached_enabled is None
+        ):
+            thread_options.web_search_mode = "disabled"
+        if thread_options.network_access_enabled is None:
+            thread_options.network_access_enabled = False
+
+        if (
+            self._performance_profile == "max"
+            and thread_options.model_reasoning_effort is None
+        ):
+            thread_options.model_reasoning_effort = "minimal"
+
+        return thread_options
+
+    def _resolve_app_server_options(
         self,
-        messages: list[ModelMessage],
-        model_settings: Optional[ModelSettings],
-        model_request_parameters: ModelRequestParameters,
-    ) -> tuple[List[Any], RequestUsage, str, ModelRequestParameters]:
-        """
-        Run a Codex thread for the given conversation and request parameters, and parse the JSON envelope into response parts.
+        *,
+        app_server_options: Optional[AppServerOptions],
+        codex_options: Optional[CodexOptions],
+    ) -> AppServerOptions:
+        """Resolve app-server options."""
+        if app_server_options is not None:
+            return app_server_options
 
-        Args:
-            messages: Conversation messages to include in the Codex prompt.
-            model_settings: Ignored by this implementation.
-            model_request_parameters: Controls function/output tool definitions, whether
-                text output is allowed, and may be customized before the request.
+        if codex_options is None:
+            return AppServerOptions()
 
-        Returns:
-            Tuple of `(parts, usage, thread_id, model_request_parameters)`:
-            - `parts`: Response parts parsed from the envelope (ToolCallPart for tool calls
-              or TextPart for final text).
-            - `usage`: Usage information for the request.
-            - `thread_id`: The Codex thread identifier used for the request.
-            - `model_request_parameters`: The (possibly customized) request parameters
-              actually used for the request.
-        """
-        model_settings, model_request_parameters = self.prepare_request(
-            model_settings, model_request_parameters
+        return AppServerOptions(
+            codex_path_override=codex_options.codex_path_override,
+            base_url=codex_options.base_url,
+            api_key=codex_options.api_key,
+            env=codex_options.env,
+            config_overrides=codex_options.config_overrides,
         )
-        del model_settings
 
+    def _thread_start_params(self) -> Dict[str, Any]:
+        """Build app-server `thread/start` params from current thread options."""
+        params: Dict[str, Any] = {}
+        options = self._thread_options
+
+        if options.model is not None:
+            params["model"] = options.model
+        if options.working_directory is not None:
+            params["cwd"] = str(options.working_directory)
+        if options.sandbox_mode is not None:
+            params["sandbox_mode"] = options.sandbox_mode
+        if options.skip_git_repo_check is not None:
+            params["skip_git_repo_check"] = options.skip_git_repo_check
+        if options.model_reasoning_effort is not None:
+            params["model_reasoning_effort"] = options.model_reasoning_effort
+        if options.model_instructions_file is not None:
+            params["model_instructions_file"] = str(options.model_instructions_file)
+        if options.model_personality is not None:
+            params["model_personality"] = options.model_personality
+        if options.max_threads is not None:
+            params["max_threads"] = options.max_threads
+        if options.network_access_enabled is not None:
+            params["network_access_enabled"] = options.network_access_enabled
+        if options.web_search_mode is not None:
+            params["web_search_mode"] = options.web_search_mode
+        if options.web_search_enabled is not None:
+            params["web_search_enabled"] = options.web_search_enabled
+        if options.web_search_cached_enabled is not None:
+            params["web_search_cached_enabled"] = options.web_search_cached_enabled
+        if options.shell_snapshot_enabled is not None:
+            params["shell_snapshot_enabled"] = options.shell_snapshot_enabled
+        if options.background_terminals_enabled is not None:
+            params["background_terminals_enabled"] = (
+                options.background_terminals_enabled
+            )
+        if options.apply_patch_freeform_enabled is not None:
+            params["apply_patch_freeform_enabled"] = (
+                options.apply_patch_freeform_enabled
+            )
+        if options.exec_policy_enabled is not None:
+            params["exec_policy_enabled"] = options.exec_policy_enabled
+        if options.remote_models_enabled is not None:
+            params["remote_models_enabled"] = options.remote_models_enabled
+        if options.collaboration_modes_enabled is not None:
+            params["collaboration_modes_enabled"] = options.collaboration_modes_enabled
+        if options.connectors_enabled is not None:
+            params["connectors_enabled"] = options.connectors_enabled
+        if options.responses_websockets_enabled is not None:
+            params["responses_websockets_enabled"] = (
+                options.responses_websockets_enabled
+            )
+        if options.request_compression_enabled is not None:
+            params["request_compression_enabled"] = options.request_compression_enabled
+        if options.feature_overrides is not None:
+            params["feature_overrides"] = _jsonable(options.feature_overrides)
+        if options.approval_policy is not None:
+            params["approval_policy"] = options.approval_policy
+        if options.additional_directories is not None:
+            params["additional_directories"] = list(options.additional_directories)
+        if options.config_overrides is not None:
+            params["config_overrides"] = _jsonable(options.config_overrides)
+
+        return params
+
+    async def _ensure_thread(self, messages: Sequence[ModelMessage]) -> str:
+        """Ensure a reusable Codex thread exists for the current message stream."""
+        history_len = len(messages)
+        if self._thread_id is not None:
+            should_reset = history_len < self._messages_seen
+            if self._thread_reuse_mode == "run" and history_len <= self._messages_seen:
+                should_reset = True
+            if should_reset:
+                self._thread_id = None
+                self._messages_seen = 0
+
+        if self._thread_id:
+            return self._thread_id
+
+        client = await self._ensure_client()
+        response = await client.thread_start(**self._thread_start_params())
+        thread = response.get("thread") if isinstance(response, dict) else None
+        thread_id = thread.get("id") if isinstance(thread, Mapping) else None
+        if not isinstance(thread_id, str) or not thread_id:
+            raise CodexError("thread/start response missing thread id")
+        self._thread_id = thread_id
+        self._messages_seen = 0
+        return thread_id
+
+    def _slice_incremental_messages(
+        self, messages: Sequence[ModelMessage]
+    ) -> tuple[List[ModelMessage], int]:
+        """Return only messages not yet sent to Codex thread state."""
+        start = min(self._messages_seen, len(messages))
+        incremental = list(messages[start:])
+        if not incremental and messages:
+            incremental = [messages[-1]]
+        return incremental, len(messages)
+
+    def _build_prompt(
+        self,
+        *,
+        messages: Sequence[ModelMessage],
+        model_request_parameters: ModelRequestParameters,
+    ) -> str:
+        """Build prompt text for a single app-server turn."""
         tool_defs = [
             *model_request_parameters.function_tools,
             *model_request_parameters.output_tools,
         ]
         tool_names = [tool.name for tool in tool_defs]
-        output_schema = _build_envelope_schema(tool_names)
-
+        envelope_schema = _build_envelope_schema(tool_names)
         tool_manifest = _render_tool_definitions(
             function_tools=model_request_parameters.function_tools,
             output_tools=model_request_parameters.output_tools,
         )
-
         allow_text_output = model_request_parameters.allow_text_output
+
         prompt_sections = [
             "You are a model in a tool-calling loop controlled by the host application.",
             "You MUST NOT run shell commands, edit files, or call any built-in tools.",
@@ -535,6 +946,7 @@ class CodexModel(Model):
             '- Each tool call is: {"id": "...", "name": "...", "arguments": "{...json...}"}',
             "- arguments MUST be a JSON string encoding an object.",
             "- If you are calling any tools, set final to an empty string.",
+            f"- The output object must validate this schema: {_json_dumps(envelope_schema)}",
         ]
         if allow_text_output:
             prompt_sections.append(
@@ -552,47 +964,194 @@ class CodexModel(Model):
         if history:
             prompt_sections.extend(["", "Conversation so far:", history])
 
-        prompt = "\n".join(prompt_sections).strip()
+        return "\n".join(prompt_sections).strip()
+
+    def _handle_notification(
+        self,
+        *,
+        notification: AppServerNotification,
+        state: _TurnAccumulationState,
+        streamed: Optional[CodexStreamedResponse],
+        allow_stream_text: bool,
+    ) -> None:
+        """Update accumulated state from one app-server notification."""
+        failure = _extract_turn_failure_message(notification)
+        if failure:
+            state.turn_failed_message = failure
+
+        params = notification.params
+        if isinstance(params, Mapping):
+            usage = _usage_from_mapping(params.get("usage"))
+            if usage is not None:
+                state.usage = usage
+            turn = params.get("turn")
+            if isinstance(turn, Mapping):
+                turn_usage = _extract_usage_from_turn(turn)
+                if turn_usage is not None:
+                    state.usage = turn_usage
+
+        for item in _notification_items(notification):
+            text = _extract_agent_text_from_item(item)
+            if not text:
+                continue
+
+            state.latest_agent_text = text
+            if not allow_stream_text or streamed is None:
+                continue
+
+            item_id_raw = item.get("id")
+            item_id = (
+                str(item_id_raw) if item_id_raw is not None else "__agent_message__"
+            )
+            previous = state.item_text_by_id.get(item_id, "")
+            if text.startswith(previous):
+                delta = text[len(previous) :]
+            else:
+                delta = text
+            state.item_text_by_id[item_id] = text
+            state.last_updated_item_id = item_id
+            if not delta:
+                continue
+
+            if item_id not in state.vendor_part_ids:
+                state.vendor_part_ids[item_id] = state.next_vendor_part_id
+                state.next_vendor_part_id += 1
+            vendor_part_id = state.vendor_part_ids[item_id]
+            streamed.push_text_delta(vendor_part_id=vendor_part_id, content=delta)
+
+    async def _run_turn(
+        self,
+        *,
+        thread_id: str,
+        prompt: str,
+        model_request_parameters: ModelRequestParameters,
+        streamed: Optional[CodexStreamedResponse] = None,
+    ) -> tuple[List[Any], RequestUsage]:
+        """Execute one app-server turn and parse it into PydanticAI parts."""
+        client = await self._ensure_client()
+        session = await client.turn_session(thread_id, prompt)
+        state = _TurnAccumulationState()
+
+        allow_stream_text = bool(
+            streamed is not None
+            and model_request_parameters.allow_text_output
+            and not model_request_parameters.function_tools
+            and not model_request_parameters.output_tools
+        )
+
+        async for notification in session.notifications():
+            self._handle_notification(
+                notification=notification,
+                state=state,
+                streamed=streamed,
+                allow_stream_text=allow_stream_text,
+            )
+
+        final_turn = await session.wait()
+        if state.turn_failed_message:
+            raise TurnFailedError(state.turn_failed_message)
+
+        usage = state.usage or _extract_usage_from_turn(final_turn) or RequestUsage()
+        final_text = _extract_turn_text(final_turn)
+        if not final_text:
+            final_text = state.latest_agent_text
+
+        parsed_json = _extract_json_object(final_text) if final_text else None
+        parsed_envelope = parsed_json if _is_envelope_candidate(parsed_json) else None
+
+        parts: List[Any] = []
+        tool_calls = _tool_calls_from_envelope(parsed_envelope)
+        if tool_calls:
+            for index, call in enumerate(tool_calls):
+                parts.append(
+                    ToolCallPart(
+                        tool_name=call.tool_name,
+                        args=call.arguments_json,
+                        tool_call_id=call.tool_call_id,
+                    )
+                )
+                if streamed is not None:
+                    streamed.push_tool_call(
+                        vendor_part_id=index,
+                        tool_name=call.tool_name,
+                        args=call.arguments_json,
+                        tool_call_id=call.tool_call_id,
+                    )
+            return parts, usage
+
+        if parsed_envelope is not None:
+            final_value = _final_from_envelope(parsed_envelope)
+        else:
+            final_value = final_text
+
+        if model_request_parameters.allow_text_output and final_value:
+            parts.append(TextPart(final_value))
+            if streamed is not None:
+                if allow_stream_text:
+                    if not state.item_text_by_id:
+                        streamed.push_text_delta(vendor_part_id=0, content=final_value)
+                    else:
+                        last_item_id = (
+                            state.last_updated_item_id
+                            if state.last_updated_item_id in state.item_text_by_id
+                            else next(reversed(state.item_text_by_id))
+                        )
+                        last_text = state.item_text_by_id[last_item_id]
+                        if final_value.startswith(last_text):
+                            remainder = final_value[len(last_text) :]
+                            if remainder:
+                                vendor_part_id = state.vendor_part_ids.get(
+                                    last_item_id, 0
+                                )
+                                streamed.push_text_delta(
+                                    vendor_part_id=vendor_part_id,
+                                    content=remainder,
+                                )
+                        elif final_value != last_text:
+                            streamed.push_text_delta(
+                                vendor_part_id=state.next_vendor_part_id,
+                                content=final_value,
+                            )
+                else:
+                    streamed.push_text_delta(vendor_part_id=0, content=final_value)
+
+        return parts, usage
+
+    async def _run_codex_request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: Optional[ModelSettings],
+        model_request_parameters: ModelRequestParameters,
+        streamed: Optional[CodexStreamedResponse] = None,
+    ) -> tuple[List[Any], RequestUsage, str, ModelRequestParameters]:
+        """Run one model request via app-server transport."""
+        model_settings, model_request_parameters = self.prepare_request(
+            model_settings, model_request_parameters
+        )
+        del model_settings
+
+        thread_id = await self._ensure_thread(messages)
+        incremental_messages, seen_after = self._slice_incremental_messages(messages)
+        prompt = self._build_prompt(
+            messages=incremental_messages,
+            model_request_parameters=model_request_parameters,
+        )
 
         with span(
             "codex_sdk.pydantic_ai.model_request",
             model=self._thread_options.model,
             sandbox_mode=self._thread_options.sandbox_mode,
+            transport="app_server",
+            performance_profile=self._performance_profile,
         ):
-            thread = self._codex.start_thread(self._thread_options)
-            parsed_turn = await thread.run_json(
-                prompt, output_schema=output_schema, turn_options=TurnOptions()
+            parts, usage = await self._run_turn(
+                thread_id=thread_id,
+                prompt=prompt,
+                model_request_parameters=model_request_parameters,
+                streamed=streamed,
             )
 
-        usage = RequestUsage()
-        if parsed_turn.turn.usage is not None:
-            cached = parsed_turn.turn.usage.cached_input_tokens
-            details = {"cached_input_tokens": cached} if cached else {}
-            usage = RequestUsage(
-                input_tokens=parsed_turn.turn.usage.input_tokens,
-                cache_read_tokens=cached,
-                output_tokens=parsed_turn.turn.usage.output_tokens,
-                details=details,
-            )
-
-        tool_calls = _tool_calls_from_envelope(parsed_turn.output)
-        parts: List[Any] = []
-        if tool_calls:
-            parts.extend(
-                ToolCallPart(
-                    tool_name=call.tool_name,
-                    args=call.arguments_json,
-                    tool_call_id=call.tool_call_id,
-                )
-                for call in tool_calls
-            )
-        else:
-            final = _final_from_envelope(parsed_turn.output)
-            if allow_text_output and final:
-                parts.append(TextPart(final))
-
-        thread_id = thread.id
-        assert thread_id is not None
+        self._messages_seen = seen_after
         return parts, usage, thread_id, model_request_parameters
 
     async def request(
@@ -601,23 +1160,19 @@ class CodexModel(Model):
         model_settings: Optional[ModelSettings],
         model_request_parameters: ModelRequestParameters,
     ) -> ModelResponse:
-        """
-        Send the provided message history to Codex and return a ModelResponse containing the model output and metadata.
+        """Run a request and return a completed model response."""
+        async with self._request_lock:
+            try:
+                parts, usage, thread_id, _ = await self._run_codex_request(
+                    messages=messages,
+                    model_settings=model_settings,
+                    model_request_parameters=model_request_parameters,
+                )
+            except Exception:
+                self._thread_id = None
+                self._messages_seen = 0
+                raise
 
-        Args:
-            messages: The conversation as a list of ModelMessage objects to send to the model.
-            model_settings: Optional model configuration (may be ignored by the Codex backend).
-            model_request_parameters: Request-specific parameters that influence Codex execution.
-
-        Returns:
-            ModelResponse containing the generated parts, usage information, the model name,
-            and provider_details with the Codex `thread_id`.
-        """
-        parts, usage, thread_id, _ = await self._run_codex_request(
-            messages,
-            model_settings,
-            model_request_parameters,
-        )
         return ModelResponse(
             parts=parts,
             usage=usage,
@@ -634,30 +1189,39 @@ class CodexModel(Model):
         model_request_parameters: ModelRequestParameters,
         run_context: Optional[Any] = None,
     ) -> AsyncIterator[StreamedResponse]:
-        """
-        Produce an asynchronous stream that yields a Codex-backed streamed model response for the given message sequence.
+        """Run a request and stream incremental response events."""
+        del run_context
+        async with self._request_lock:
+            streamed = CodexStreamedResponse(
+                model_request_parameters=model_request_parameters,
+                model_name=self.model_name,
+                provider_name=self.system,
+            )
 
-        Args:
-            messages: Conversation messages to send to the model.
-            model_settings: Model-specific settings (may be None).
-            model_request_parameters: Additional request parameters controlling the model call.
-            run_context: Optional PydanticAI run context. Accepted for compatibility
-                with PydanticAI stream-call contracts and currently unused by Codex.
+            async def _runner() -> None:
+                thread_id: Optional[str] = self._thread_id
+                try:
+                    parts, usage, thread_id, _ = await self._run_codex_request(
+                        messages=messages,
+                        model_settings=model_settings,
+                        model_request_parameters=model_request_parameters,
+                        streamed=streamed,
+                    )
+                    del parts
+                    streamed.finish(usage=usage, thread_id=thread_id)
+                except Exception as exc:  # pragma: no cover - defensive
+                    self._thread_id = None
+                    self._messages_seen = 0
+                    streamed.finish(thread_id=thread_id, error=exc)
 
-        Returns:
-            An async iterator that yields a single StreamedResponse (CodexStreamedResponse) containing the model name, response parts, usage information, and the Codex thread identifier.
-        """
-        parts, usage, thread_id, used_params = await self._run_codex_request(
-            messages,
-            model_settings,
-            model_request_parameters,
-        )
-        streamed = CodexStreamedResponse(
-            model_request_parameters=used_params,
-            model_name=self.model_name,
-            provider_name=self.system,
-            parts=parts,
-            thread_id=thread_id,
-            usage=usage,
-        )
-        yield streamed
+            task = asyncio.create_task(_runner())
+            try:
+                yield streamed
+                await task
+            finally:
+                if not task.done():
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass

--- a/src/codex_sdk/integrations/pydantic_ai_model.py
+++ b/src/codex_sdk/integrations/pydantic_ai_model.py
@@ -17,7 +17,7 @@ import json
 import logging
 from base64 import b64encode
 from contextlib import asynccontextmanager
-from dataclasses import asdict, dataclass, field, is_dataclass
+from dataclasses import asdict, dataclass, field, is_dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, Iterator, List, Mapping, Optional, Sequence
@@ -772,31 +772,30 @@ class CodexModel(Model):
         self, thread_options: Optional[ThreadOptions]
     ) -> ThreadOptions:
         """Apply model-provider defaults to thread options."""
-        if thread_options is None:
-            thread_options = ThreadOptions()
+        options = replace(thread_options) if thread_options is not None else ThreadOptions()
 
-        if thread_options.skip_git_repo_check is None:
-            thread_options.skip_git_repo_check = True
-        if thread_options.sandbox_mode is None:
-            thread_options.sandbox_mode = "read-only"
-        if thread_options.approval_policy is None:
-            thread_options.approval_policy = "never"
+        if options.skip_git_repo_check is None:
+            options.skip_git_repo_check = True
+        if options.sandbox_mode is None:
+            options.sandbox_mode = "read-only"
+        if options.approval_policy is None:
+            options.approval_policy = "never"
         if (
-            thread_options.web_search_mode is None
-            and thread_options.web_search_enabled is None
-            and thread_options.web_search_cached_enabled is None
+            options.web_search_mode is None
+            and options.web_search_enabled is None
+            and options.web_search_cached_enabled is None
         ):
-            thread_options.web_search_mode = "disabled"
-        if thread_options.network_access_enabled is None:
-            thread_options.network_access_enabled = False
+            options.web_search_mode = "disabled"
+        if options.network_access_enabled is None:
+            options.network_access_enabled = False
 
         if (
             self._performance_profile == "max"
-            and thread_options.model_reasoning_effort is None
+            and options.model_reasoning_effort is None
         ):
-            thread_options.model_reasoning_effort = "minimal"
+            options.model_reasoning_effort = "minimal"
 
-        return thread_options
+        return options
 
     def _resolve_app_server_options(
         self,

--- a/src/codex_sdk/integrations/pydantic_ai_model.py
+++ b/src/codex_sdk/integrations/pydantic_ai_model.py
@@ -1224,4 +1224,5 @@ class CodexModel(Model):
                     try:
                         await task
                     except asyncio.CancelledError:
+                        # Expected when cancelling the background task during cleanup; safe to ignore.
                         pass

--- a/tests/test_pydantic_ai_model.py
+++ b/tests/test_pydantic_ai_model.py
@@ -627,7 +627,7 @@ def test_codex_model_can_construct_codex_from_options():
 
 def test_codex_model_rejects_legacy_codex_argument():
     with pytest.raises(TypeError):
-        CodexModel(codex=object())  # type: ignore[call-arg]
+        CodexModel(**{"codex": object()})
 
 
 @pytest.mark.asyncio

--- a/tests/test_pydantic_ai_model.py
+++ b/tests/test_pydantic_ai_model.py
@@ -1053,6 +1053,31 @@ async def test_codex_model_close_closes_owned_app_server(monkeypatch):
         )
 
 
+@pytest.mark.asyncio
+async def test_codex_model_close_does_not_close_external_app_server():
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-external",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": "ok",
+        },
+    )
+    model = CodexModel(app_server=app)
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    await model.request([ModelRequest(parts=[UserPromptPart("hi")])], None, params)
+    assert app.start_calls >= 1
+
+    await model.close()
+    assert app.close_calls == 0
+
+    with pytest.raises(CodexError, match="closed"):
+        await model.request(
+            [ModelRequest(parts=[UserPromptPart("again")])], None, params
+        )
+
+
 def test_codex_model_rejects_invalid_profile_values():
     with pytest.raises(CodexError, match="performance_profile"):
         CodexModel(performance_profile="fast")

--- a/tests/test_pydantic_ai_model.py
+++ b/tests/test_pydantic_ai_model.py
@@ -1,5 +1,6 @@
 import dataclasses
 import importlib
+import json
 from contextlib import asynccontextmanager
 
 import pytest
@@ -11,20 +12,28 @@ pydantic = pytest.importorskip("pydantic")
 pytest.importorskip("pydantic_ai", exc_type=ImportError)
 BaseModel = pydantic.BaseModel
 
-from codex_sdk.events import Usage
+from codex_sdk.app_server import AppServerNotification, AppServerOptions
+from codex_sdk.exceptions import CodexError, TurnFailedError
 from codex_sdk.integrations.pydantic_ai_model import (
     CodexModel,
     CodexStreamedResponse,
     _build_envelope_schema,
+    _extract_json_object,
+    _extract_turn_failure_message,
+    _extract_turn_text,
+    _extract_usage_from_turn,
     _final_from_envelope,
+    _is_envelope_candidate,
     _json_dumps,
     _jsonable,
+    _notification_items,
     _render_message_history,
     _render_tool_definitions,
+    _to_int,
     _tool_calls_from_envelope,
+    _usage_from_mapping,
 )
-from codex_sdk.options import CodexOptions
-from codex_sdk.thread import ParsedTurn, Turn
+from codex_sdk.options import CodexOptions, ThreadOptions
 
 messages = importlib.import_module("pydantic_ai.messages")
 models = importlib.import_module("pydantic_ai.models")
@@ -48,32 +57,8 @@ ToolDefinition = tools.ToolDefinition
 RequestUsage = importlib.import_module("pydantic_ai.usage").RequestUsage
 
 
-class FakeThread:
-    def __init__(self, output):
-        self._output = output
-        self.id = "thread-123"
-        self.last_prompt = None
-        self.last_schema = None
-
-    async def run_json(self, prompt, *, output_schema, turn_options=None):
-        self.last_prompt = prompt
-        self.last_schema = output_schema
-        turn = Turn(
-            items=[],
-            final_response="",
-            usage=Usage(input_tokens=1, cached_input_tokens=2, output_tokens=3),
-        )
-        return ParsedTurn(turn=turn, output=self._output)
-
-
-class FakeCodex:
-    def __init__(self, thread):
-        self._thread = thread
-        self.last_thread_options = None
-
-    def start_thread(self, options=None):
-        self.last_thread_options = options
-        return self._thread
+def _envelope_json(output):
+    return json.dumps(output, separators=(",", ":"))
 
 
 @pytest.mark.asyncio
@@ -84,9 +69,16 @@ async def test_codex_model_returns_tool_calls():
         ],
         "final": "",
     }
-    thread = FakeThread(output)
-    codex = FakeCodex(thread)
-    model = CodexModel(codex=codex)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-tools",
+            "usage": {"inputTokens": 1, "cachedInputTokens": 2, "outputTokens": 3},
+            "finalResponse": _envelope_json(output),
+        },
+        thread_id="thread-123",
+    )
+    model = CodexModel(app_server=app)
 
     messages = [ModelRequest(parts=[UserPromptPart("hi")])]
     params = ModelRequestParameters(
@@ -115,11 +107,8 @@ async def test_codex_model_returns_tool_calls():
     assert response.usage.output_tokens == 3
     assert response.usage.details == {"cached_input_tokens": 2}
 
-    # Schema should restrict tool names
-    enum = thread.last_schema["properties"]["tool_calls"]["items"]["properties"][
-        "name"
-    ]["enum"]
-    assert enum == ["add"]
+    prompt = app.turn_session_calls[0]["input"]
+    assert '"enum":["add"]' in prompt
 
 
 def test_render_tool_definitions_renders_optional_tool_fields() -> None:
@@ -158,8 +147,14 @@ def test_codex_model_does_not_override_explicit_thread_options() -> None:
     """Cover CodexModel.__init__ branches when thread options are preconfigured."""
     profiles = importlib.import_module("pydantic_ai.profiles")
 
-    thread = FakeThread({"tool_calls": [], "final": "ok"})
-    codex = FakeCodex(thread)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-explicit",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "ok"}),
+        },
+    )
     thread_options = importlib.import_module("codex_sdk.options").ThreadOptions(
         skip_git_repo_check=False,
         sandbox_mode="workspace-write",
@@ -169,7 +164,7 @@ def test_codex_model_does_not_override_explicit_thread_options() -> None:
     )
 
     profile = profiles.ModelProfile(supports_tools=False)
-    model = CodexModel(codex=codex, thread_options=thread_options, profile=profile)
+    model = CodexModel(app_server=app, thread_options=thread_options, profile=profile)
 
     assert model.model_name == "codex"
     assert thread_options.skip_git_repo_check is False
@@ -182,17 +177,14 @@ def test_codex_model_does_not_override_explicit_thread_options() -> None:
 @pytest.mark.asyncio
 async def test_codex_model_usage_defaults_when_thread_usage_missing() -> None:
     """Cover the branch where turn.usage is None and we return minimal usage."""
-
-    class FakeThreadNoUsage(FakeThread):
-        async def run_json(self, prompt, *, output_schema, turn_options=None):
-            self.last_prompt = prompt
-            self.last_schema = output_schema
-            turn = Turn(items=[], final_response="", usage=None)
-            return ParsedTurn(turn=turn, output={"tool_calls": [], "final": "hi"})
-
-    thread = FakeThreadNoUsage({"tool_calls": [], "final": "hi"})
-    codex = FakeCodex(thread)
-    model = CodexModel(codex=codex)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-no-usage",
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "hi"}),
+        },
+    )
+    model = CodexModel(app_server=app)
 
     reqs = [ModelRequest(parts=[UserPromptPart("hi")])]
     params = ModelRequestParameters(output_mode="text", allow_text_output=True)
@@ -205,9 +197,15 @@ async def test_codex_model_usage_defaults_when_thread_usage_missing() -> None:
 @pytest.mark.asyncio
 async def test_codex_model_request_without_history() -> None:
     """Cover the prompt path where message history is empty."""
-    thread = FakeThread({"tool_calls": [], "final": "hello"})
-    codex = FakeCodex(thread)
-    model = CodexModel(codex=codex)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-empty-history",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "hello"}),
+        },
+    )
+    model = CodexModel(app_server=app)
 
     params = ModelRequestParameters(output_mode="text", allow_text_output=True)
     response = await model.request([], None, params)
@@ -218,9 +216,15 @@ async def test_codex_model_request_without_history() -> None:
 @pytest.mark.asyncio
 async def test_codex_model_returns_text_when_allowed():
     output = {"tool_calls": [], "final": "hello"}
-    thread = FakeThread(output)
-    codex = FakeCodex(thread)
-    model = CodexModel(codex=codex)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-text",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json(output),
+        },
+    )
+    model = CodexModel(app_server=app)
 
     messages = [ModelRequest(parts=[UserPromptPart("hi")])]
     params = ModelRequestParameters(output_mode="text", allow_text_output=True)
@@ -234,9 +238,15 @@ async def test_codex_model_returns_text_when_allowed():
 @pytest.mark.asyncio
 async def test_codex_model_omits_text_when_not_allowed():
     output = {"tool_calls": [], "final": "hello"}
-    thread = FakeThread(output)
-    codex = FakeCodex(thread)
-    model = CodexModel(codex=codex)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-no-text",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json(output),
+        },
+    )
+    model = CodexModel(app_server=app)
 
     messages = [ModelRequest(parts=[UserPromptPart("hi")])]
     params = ModelRequestParameters(output_mode="tool", allow_text_output=False)
@@ -246,9 +256,15 @@ async def test_codex_model_omits_text_when_not_allowed():
 
 
 def test_model_name_and_system_properties():
-    thread = FakeThread({"tool_calls": [], "final": ""})
-    codex = FakeCodex(thread)
-    model = CodexModel(codex=codex, system="custom")
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-system",
+            "usage": {"inputTokens": 0, "outputTokens": 0},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": ""}),
+        },
+    )
+    model = CodexModel(app_server=app, system="custom")
     assert model.model_name == "codex"
     assert model.system == "custom"
 
@@ -458,9 +474,15 @@ def test_render_message_history_handles_non_callable_tool_return_and_retry():
 @pytest.mark.asyncio
 async def test_codex_model_includes_tool_manifest_and_history_in_prompt():
     output = {"tool_calls": [], "final": "hello"}
-    thread = FakeThread(output)
-    codex = FakeCodex(thread)
-    model = CodexModel(codex=codex)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-manifest",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json(output),
+        },
+    )
+    model = CodexModel(app_server=app)
 
     messages = [
         ModelRequest(
@@ -499,17 +521,24 @@ async def test_codex_model_includes_tool_manifest_and_history_in_prompt():
     )
 
     await model.request(messages, None, params)
-    assert "Function tools:" in thread.last_prompt
-    assert "Output tools" in thread.last_prompt
-    assert "Conversation so far:" in thread.last_prompt
+    prompt = app.turn_session_calls[0]["input"]
+    assert "Function tools:" in prompt
+    assert "Output tools" in prompt
+    assert "Conversation so far:" in prompt
 
 
 @pytest.mark.asyncio
 async def test_codex_model_request_stream_yields_response():
-    output = {"tool_calls": [], "final": "hello"}
-    thread = FakeThread(output)
-    codex = FakeCodex(thread)
-    model = CodexModel(codex=codex)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-stream-response",
+            "usage": {"inputTokens": 1, "cachedInputTokens": 2, "outputTokens": 3},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "hello"}),
+        },
+        thread_id="thread-123",
+    )
+    model = CodexModel(app_server=app)
 
     messages = [ModelRequest(parts=[UserPromptPart("hi")])]
     params = ModelRequestParameters(output_mode="text", allow_text_output=True)
@@ -528,10 +557,15 @@ async def test_codex_model_request_stream_yields_response():
 
 @pytest.mark.asyncio
 async def test_codex_model_request_stream_accepts_run_context_argument():
-    output = {"tool_calls": [], "final": "hello"}
-    thread = FakeThread(output)
-    codex = FakeCodex(thread)
-    model = CodexModel(codex=codex)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-run-context",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "hello"}),
+        },
+    )
+    model = CodexModel(app_server=app)
 
     messages = [ModelRequest(parts=[UserPromptPart("hi")])]
     params = ModelRequestParameters(output_mode="text", allow_text_output=True)
@@ -548,8 +582,8 @@ async def test_codex_model_request_stream_accepts_run_context_argument():
 @pytest.mark.asyncio
 async def test_agent_run_stream_passes_run_context_to_codex_model():
     class CapturingCodexModel(CodexModel):
-        def __init__(self, *, codex):
-            super().__init__(codex=codex)
+        def __init__(self, *, app_server):
+            super().__init__(app_server=app_server)
             self.last_run_context = None
 
         @asynccontextmanager
@@ -569,10 +603,15 @@ async def test_agent_run_stream_passes_run_context_to_codex_model():
             ) as streamed:
                 yield streamed
 
-    output = {"tool_calls": [], "final": "hello"}
-    thread = FakeThread(output)
-    codex = FakeCodex(thread)
-    model = CapturingCodexModel(codex=codex)
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-agent-run-context",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "hello"}),
+        },
+    )
+    model = CapturingCodexModel(app_server=app)
     agent = Agent(model=model, output_type=str)
 
     async with agent.run_stream("hi") as result:
@@ -584,6 +623,11 @@ async def test_agent_run_stream_passes_run_context_to_codex_model():
 
 def test_codex_model_can_construct_codex_from_options():
     CodexModel(codex_options=CodexOptions(codex_path_override="codex-binary"))
+
+
+def test_codex_model_rejects_legacy_codex_argument():
+    with pytest.raises(TypeError):
+        CodexModel(codex=object())  # type: ignore[call-arg]
 
 
 @pytest.mark.asyncio
@@ -607,3 +651,503 @@ async def test_streamed_response_emits_tool_calls_and_skips_unknown_parts():
     events = [event async for event in resp]
     assert events
     assert resp.provider_url is None
+
+
+@pytest.mark.asyncio
+async def test_streamed_response_supports_iterator_text_delta_api(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Accept both old (single-event) and new (iterator) text-delta manager APIs."""
+    resp = CodexStreamedResponse(
+        model_request_parameters=ModelRequestParameters(
+            output_mode="text",
+            allow_text_output=True,
+        ),
+        model_name="m",
+        provider_name="openai",
+        parts=[TextPart("hello")],
+        thread_id="thread-123",
+        usage=RequestUsage(),
+    )
+
+    original_handle_text_delta = resp._parts_manager.handle_text_delta
+
+    def _iterator_handle_text_delta(*, vendor_part_id, content):
+        result = original_handle_text_delta(
+            vendor_part_id=vendor_part_id,
+            content=content,
+        )
+        if hasattr(result, "event_kind"):
+            return iter([result])
+        return result
+
+    monkeypatch.setattr(
+        resp._parts_manager, "handle_text_delta", _iterator_handle_text_delta
+    )
+
+    events = [event async for event in resp]
+
+    assert any(isinstance(event, PartStartEvent) for event in events)
+    model_response = resp.get()
+    assert len(model_response.parts) == 1
+    assert isinstance(model_response.parts[0], TextPart)
+    assert model_response.parts[0].content == "hello"
+
+
+class FakeAppServerTurnSession:
+    def __init__(self, notifications, final_turn):
+        self._notifications = list(notifications)
+        self._final_turn = dict(final_turn)
+
+    async def notifications(self):
+        for notification in self._notifications:
+            yield notification
+
+    async def wait(self):
+        return self._final_turn
+
+
+class FakeAppServerClient:
+    def __init__(self, *, notifications, final_turn, thread_id="thread-app"):
+        self._notifications = list(notifications)
+        self._final_turn = dict(final_turn)
+        self._thread_id = thread_id
+        self.start_calls = 0
+        self.close_calls = 0
+        self.thread_start_calls = []
+        self.turn_session_calls = []
+
+    async def start(self):
+        self.start_calls += 1
+
+    async def close(self):
+        self.close_calls += 1
+
+    async def thread_start(self, **params):
+        self.thread_start_calls.append(dict(params))
+        return {"thread": {"id": self._thread_id}}
+
+    async def turn_session(self, thread_id, input, **params):
+        self.turn_session_calls.append(
+            {"thread_id": thread_id, "input": input, "params": dict(params)}
+        )
+        return FakeAppServerTurnSession(self._notifications, self._final_turn)
+
+
+@pytest.mark.asyncio
+async def test_codex_model_default_path_uses_app_server_and_returns_tool_calls():
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-1",
+            "usage": {"inputTokens": 4, "cachedInputTokens": 1, "outputTokens": 2},
+            "finalResponse": (
+                '{"tool_calls":[{"id":"call_1","name":"add","arguments":"{\\"a\\":1,\\"b\\":2}"}],'
+                '"final":""}'
+            ),
+        },
+    )
+    model = CodexModel(app_server=app)
+
+    response = await model.request(
+        [ModelRequest(parts=[UserPromptPart("calculate")])],
+        None,
+        ModelRequestParameters(
+            output_mode="tool",
+            allow_text_output=False,
+            function_tools=[
+                ToolDefinition(
+                    name="add",
+                    description="add two numbers",
+                    parameters_json_schema={
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "integer"},
+                            "b": {"type": "integer"},
+                        },
+                        "required": ["a", "b"],
+                        "additionalProperties": False,
+                    },
+                )
+            ],
+        ),
+    )
+
+    assert app.start_calls >= 1
+    assert len(app.thread_start_calls) == 1
+    assert len(app.turn_session_calls) == 1
+    assert response.provider_details == {"thread_id": "thread-app"}
+    assert response.usage.input_tokens == 4
+    assert response.usage.cache_read_tokens == 1
+    assert response.usage.output_tokens == 2
+    assert len(response.parts) == 1
+    assert isinstance(response.parts[0], ToolCallPart)
+    assert response.parts[0].tool_name == "add"
+    assert response.parts[0].tool_call_id == "call_1"
+    assert response.parts[0].args == '{"a":1,"b":2}'
+
+
+@pytest.mark.asyncio
+async def test_codex_model_default_stream_emits_incremental_text_deltas():
+    app = FakeAppServerClient(
+        notifications=[
+            AppServerNotification(
+                method="item/updated",
+                params={"item": {"id": "m1", "type": "agent_message", "text": "hel"}},
+            ),
+            AppServerNotification(
+                method="item/updated",
+                params={"item": {"id": "m1", "type": "agent_message", "text": "hello"}},
+            ),
+        ],
+        final_turn={
+            "id": "turn-2",
+            "usage": {"inputTokens": 3, "outputTokens": 2},
+            "finalResponse": "hello",
+        },
+    )
+    model = CodexModel(app_server=app)
+
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+    async with model.request_stream(
+        [ModelRequest(parts=[UserPromptPart("say hello")])], None, params
+    ) as streamed:
+        events = [event async for event in streamed]
+        response = streamed.get()
+
+    assert app.start_calls >= 1
+    assert len(app.thread_start_calls) == 1
+    assert len(app.turn_session_calls) == 1
+    assert any(isinstance(event, PartStartEvent) for event in events)
+    assert len(response.parts) == 1
+    assert isinstance(response.parts[0], TextPart)
+    assert response.parts[0].content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_codex_model_stream_reconciles_with_most_recent_item_update():
+    app = FakeAppServerClient(
+        notifications=[
+            AppServerNotification(
+                method="item/updated",
+                params={"item": {"id": "m1", "type": "agent_message", "text": "a"}},
+            ),
+            AppServerNotification(
+                method="item/updated",
+                params={"item": {"id": "m2", "type": "agent_message", "text": "b"}},
+            ),
+            AppServerNotification(
+                method="item/updated",
+                params={"item": {"id": "m1", "type": "agent_message", "text": "abc"}},
+            ),
+        ],
+        final_turn={
+            "id": "turn-reconcile",
+            "usage": {"inputTokens": 3, "outputTokens": 2},
+            "finalResponse": "abcd",
+        },
+    )
+    model = CodexModel(app_server=app)
+
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+    async with model.request_stream(
+        [ModelRequest(parts=[UserPromptPart("say hello")])], None, params
+    ) as streamed:
+        _ = [event async for event in streamed]
+        response = streamed.get()
+
+    assert [part.content for part in response.parts if isinstance(part, TextPart)] == [
+        "abcd",
+        "b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_codex_model_default_run_reuse_mode_resets_on_equal_history_length():
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-run",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": "ok",
+        },
+    )
+    model = CodexModel(app_server=app)
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    await model.request([ModelRequest(parts=[UserPromptPart("alpha")])], None, params)
+    await model.request([ModelRequest(parts=[UserPromptPart("beta")])], None, params)
+
+    assert len(app.thread_start_calls) == 2
+    assert len(app.turn_session_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_codex_model_always_reuse_mode_reuses_on_equal_history_length():
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-always",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": "ok",
+        },
+    )
+    model = CodexModel(app_server=app, thread_reuse_mode="always")
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    await model.request([ModelRequest(parts=[UserPromptPart("alpha")])], None, params)
+    await model.request([ModelRequest(parts=[UserPromptPart("beta")])], None, params)
+
+    assert len(app.thread_start_calls) == 1
+    assert len(app.turn_session_calls) == 2
+
+
+def test_app_server_helpers_handle_edge_cases():
+    assert _extract_json_object('{"tool_calls":[],"final":"ok"}') == {
+        "tool_calls": [],
+        "final": "ok",
+    }
+    assert _extract_json_object('prefix {"tool_calls":[],"final":"ok"} suffix') == {
+        "tool_calls": [],
+        "final": "ok",
+    }
+    assert _extract_json_object("not-json") is None
+
+    assert _is_envelope_candidate({"tool_calls": []})
+    assert _is_envelope_candidate({"final": ""})
+    assert not _is_envelope_candidate([])
+
+    assert _to_int(None) == 0
+    assert _to_int("3") == 3
+    assert _to_int("not-an-int") == 0
+
+    usage = _usage_from_mapping({"input_tokens": "2", "outputTokens": 4})
+    assert usage is not None
+    assert usage.input_tokens == 2
+    assert usage.output_tokens == 4
+    assert usage.cache_read_tokens == 0
+
+    usage_from_turn = _extract_usage_from_turn({"tokenUsage": {"inputTokens": 1}})
+    assert usage_from_turn is not None
+    assert usage_from_turn.input_tokens == 1
+
+    assert _extract_turn_text({"output": {"final": "done"}}) == "done"
+    assert (
+        _extract_turn_text(
+            {"items": [{"type": "agentMessage", "content": "from-agent-message"}]}
+        )
+        == "from-agent-message"
+    )
+    assert _extract_turn_text(None) == ""
+
+    notification = AppServerNotification(
+        method="item/updated",
+        params={
+            "item": {"id": "a", "type": "agent_message", "text": "x"},
+            "items": [{"id": "b", "type": "agent_message", "text": "y"}],
+            "turn": {
+                "item": {"id": "c", "type": "agent_message", "text": "z"},
+                "items": [{"id": "d", "type": "agent_message", "text": "w"}],
+            },
+        },
+    )
+    assert [item["id"] for item in _notification_items(notification)] == [
+        "a",
+        "b",
+        "c",
+        "d",
+    ]
+
+    failure = AppServerNotification(
+        method="turn/failed",
+        params={"error": {"message": "boom"}},
+    )
+    assert _extract_turn_failure_message(failure) == "boom"
+
+    fallback_failure = AppServerNotification(method="turn/failed", params={})
+    assert _extract_turn_failure_message(fallback_failure) == "Turn failed"
+
+
+@pytest.mark.asyncio
+async def test_codex_model_default_stream_falls_back_to_final_turn_text():
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-fallback",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": "hello-from-final-turn",
+        },
+    )
+    model = CodexModel(app_server=app)
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    async with model.request_stream(
+        [ModelRequest(parts=[UserPromptPart("say hello")])], None, params
+    ) as streamed:
+        events = [event async for event in streamed]
+        response = streamed.get()
+
+    assert any(isinstance(event, PartStartEvent) for event in events)
+    assert len(response.parts) == 1
+    assert isinstance(response.parts[0], TextPart)
+    assert response.parts[0].content == "hello-from-final-turn"
+
+
+@pytest.mark.asyncio
+async def test_codex_model_stream_raises_turn_failed_error():
+    app = FakeAppServerClient(
+        notifications=[
+            AppServerNotification(
+                method="turn/failed",
+                params={"error": {"message": "approval denied"}},
+            )
+        ],
+        final_turn={
+            "id": "turn-failed",
+            "usage": {"inputTokens": 1, "outputTokens": 0},
+            "finalResponse": "",
+        },
+    )
+    model = CodexModel(app_server=app)
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    with pytest.raises(TurnFailedError, match="approval denied"):
+        async with model.request_stream(
+            [ModelRequest(parts=[UserPromptPart("fail")])], None, params
+        ) as streamed:
+            _ = [event async for event in streamed]
+
+
+@pytest.mark.asyncio
+async def test_codex_model_close_closes_owned_app_server(monkeypatch):
+    created = []
+
+    class OwnedFakeAppServer(FakeAppServerClient):
+        def __init__(self, options):
+            super().__init__(
+                notifications=[],
+                final_turn={
+                    "id": "turn-owned",
+                    "usage": {"inputTokens": 1, "outputTokens": 1},
+                    "finalResponse": "ok",
+                },
+            )
+            self.options = options
+            created.append(self)
+
+    module = importlib.import_module("codex_sdk.integrations.pydantic_ai_model")
+    monkeypatch.setattr(module, "AppServerClient", OwnedFakeAppServer)
+
+    model = CodexModel(app_server_options=AppServerOptions())
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+    await model.request([ModelRequest(parts=[UserPromptPart("hi")])], None, params)
+
+    assert created and created[0].start_calls >= 1
+
+    await model.close()
+    assert created[0].close_calls == 1
+
+    with pytest.raises(CodexError, match="closed"):
+        await model.request(
+            [ModelRequest(parts=[UserPromptPart("again")])], None, params
+        )
+
+
+def test_codex_model_rejects_invalid_profile_values():
+    with pytest.raises(CodexError, match="performance_profile"):
+        CodexModel(performance_profile="fast")
+
+    with pytest.raises(CodexError, match="thread_reuse_mode"):
+        CodexModel(thread_reuse_mode="sometimes")
+
+
+@pytest.mark.asyncio
+async def test_codex_model_thread_start_params_include_extended_options():
+    thread_options = ThreadOptions(
+        model="gpt-5",
+        sandbox_mode="workspace-write",
+        working_directory="/tmp",
+        skip_git_repo_check=False,
+        model_instructions_file="/tmp/instructions.md",
+        model_personality="friendly",
+        max_threads=3,
+        network_access_enabled=True,
+        web_search_mode="live",
+        web_search_enabled=True,
+        web_search_cached_enabled=True,
+        shell_snapshot_enabled=True,
+        background_terminals_enabled=True,
+        apply_patch_freeform_enabled=True,
+        exec_policy_enabled=True,
+        remote_models_enabled=True,
+        collaboration_modes_enabled=True,
+        connectors_enabled=True,
+        responses_websockets_enabled=True,
+        request_compression_enabled=True,
+        feature_overrides={"experimental": True},
+        approval_policy="on-request",
+        additional_directories=["/tmp/a", "/tmp/b"],
+        config_overrides={"feature": "on"},
+    )
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-opts",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": "ok",
+        },
+    )
+    model = CodexModel(
+        app_server=app,
+        thread_options=thread_options,
+        performance_profile="max",
+    )
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    await model.request([ModelRequest(parts=[UserPromptPart("opts")])], None, params)
+
+    sent = app.thread_start_calls[0]
+    assert sent["model"] == "gpt-5"
+    assert sent["cwd"] == "/tmp"
+    assert sent["sandbox_mode"] == "workspace-write"
+    assert sent["skip_git_repo_check"] is False
+    assert sent["model_instructions_file"] == "/tmp/instructions.md"
+    assert sent["model_personality"] == "friendly"
+    assert sent["max_threads"] == 3
+    assert sent["network_access_enabled"] is True
+    assert sent["web_search_mode"] == "live"
+    assert sent["web_search_enabled"] is True
+    assert sent["web_search_cached_enabled"] is True
+    assert sent["shell_snapshot_enabled"] is True
+    assert sent["background_terminals_enabled"] is True
+    assert sent["apply_patch_freeform_enabled"] is True
+    assert sent["exec_policy_enabled"] is True
+    assert sent["remote_models_enabled"] is True
+    assert sent["collaboration_modes_enabled"] is True
+    assert sent["connectors_enabled"] is True
+    assert sent["responses_websockets_enabled"] is True
+    assert sent["request_compression_enabled"] is True
+    assert sent["feature_overrides"] == {"experimental": True}
+    assert sent["approval_policy"] == "on-request"
+    assert sent["additional_directories"] == ["/tmp/a", "/tmp/b"]
+    assert sent["config_overrides"] == {"feature": "on"}
+
+
+@pytest.mark.asyncio
+async def test_codex_model_raises_when_thread_start_missing_id():
+    class MissingIdAppServer(FakeAppServerClient):
+        async def thread_start(self, **params):
+            self.thread_start_calls.append(dict(params))
+            return {"thread": {}}
+
+    app = MissingIdAppServer(
+        notifications=[],
+        final_turn={"id": "turn", "usage": {"inputTokens": 1, "outputTokens": 1}},
+    )
+    model = CodexModel(app_server=app)
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    with pytest.raises(CodexError, match="thread/start response missing thread id"):
+        await model.request(
+            [ModelRequest(parts=[UserPromptPart("oops")])], None, params
+        )


### PR DESCRIPTION
## Summary
This PR makes `CodexModel` app-server-only and aligns docs/tests to the current transport architecture.

## Why
The current README and architecture diagrams still described `CodexModel` as `codex exec` + `run_json` based, which is no longer accurate for the desired 0.105.0 behavior.

## What changed
- Migrated PydanticAI model-provider implementation to app-server-only transport:
  - `CodexModel` now runs via persistent `codex app-server` sessions.
  - Removed legacy `CodexModel(codex=...)` fallback usage path.
  - Added explicit lifecycle method: `await CodexModel.close()`.
  - Added provider controls: `performance_profile` (`balanced`/`max`) and `thread_reuse_mode` (`run`/`always`).
- Updated stream behavior:
  - `request_stream(...)` now emits incremental events during app-server turn processing.
  - Preserved compatibility across legacy/current PydanticAI stream handler return styles.
- Updated examples to reflect app-server-backed provider behavior:
  - `examples/pydantic_ai_model_provider.py`
  - `examples/pydantic_ai_run_compat.py`
  - `examples/pydantic_ai_run_stream_compat.py`
- Updated documentation to match implementation:
  - README transport table, PydanticAI section, streaming semantics, and architecture diagrams.
- Added changelog notes under `Unreleased` describing breaking change, additions, and streaming fixes.

## Files touched
- `src/codex_sdk/integrations/pydantic_ai_model.py`
- `tests/test_pydantic_ai_model.py`
- `examples/pydantic_ai_model_provider.py`
- `examples/pydantic_ai_run_compat.py`
- `examples/pydantic_ai_run_stream_compat.py`
- `README.md`
- `CHANGELOG_SDK.md`

## Validation
- `uv run pytest` (249 passed)
- `uv run mypy src` (clean)
- `uv run flake8 src tests` (clean)

## Breaking change note
Any integration relying on the legacy `CodexModel(codex=...)` path must migrate to app-server-backed `CodexModel` construction options (`app_server` or `app_server_options`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * CodexModel now requires app-server integration; legacy local Codex execution removed.

* **New Features**
  * Added `close()` method for explicit resource cleanup.
  * Added `performance_profile` option ("balanced" or "max").
  * Added `thread_reuse_mode` option ("run" or "always").

* **Bug Fixes**
  * Stream events now emit incrementally during app-server processing.
  * Improved stream compatibility across different interfaces.

* **Documentation**
  * Updated diagrams and examples to reflect app-server integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->