### PR TITLE
feat(sdk): sync Codex 0.115.0

### DIFF
--- a/CHANGELOG_SDK.md
+++ b/CHANGELOG_SDK.md
@@ -2,6 +2,31 @@
 
 This file tracks SDK-level changes. Keep the newest changes at the top.
 
+## [0.115.0] - 2026-03-17
+
+### Added
+- App-server helpers for newly exposed 0.115.0 filesystem RPCs:
+  `fs_copy`, `fs_create_directory`, `fs_get_metadata`, `fs_read_directory`,
+  `fs_read_file`, `fs_remove`, and `fs_write_file`.
+- App-server helper `plugin_read` for fetching plugin metadata from a marketplace
+  before install.
+
+### Updated
+- `CollabToolCallItem` now reflects the upstream collaboration payload by exposing
+  optional `model` and `reasoning_effort` fields for spawned agents.
+- Collaboration item parsing now accepts the renamed `wait_agent` tool and the
+  new `interrupted` collaboration agent status while keeping legacy `wait`
+  compatibility for older threads.
+- The typed SDK surface now exposes `model_reasoning_effort="none"`,
+  `approval_policy="granular"`, and `approvals_reviewer` so the CLI-backed
+  thread API and `CodexModel` match the upstream 0.115.0 thread-start contract.
+- README app-server method coverage and release version updated to 0.115.0.
+
+### Notes
+- Codex 0.115.0 adds experimental filesystem app-server RPCs, `plugin/read`,
+  guardian approval review flows, granular approval routing, and the `wait_agent`
+  collaboration tool rename.
+
 ## [0.114.1] - 2026-03-13
 
 ### Updated

--- a/CHANGELOG_SDK.md
+++ b/CHANGELOG_SDK.md
@@ -2,7 +2,7 @@
 
 This file tracks SDK-level changes. Keep the newest changes at the top.
 
-## [0.115.0] - 2026-03-17
+## [0.115.0] - Unreleased
 
 ### Added
 - App-server helpers for newly exposed 0.115.0 filesystem RPCs:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Embed the Codex agent in Python workflows. This SDK wraps the bundled `codex` CL
       <td><strong>Lifecycle</strong></td>
       <td>
         <a href="#ci-cd"><img src="https://img.shields.io/badge/CI%2FCD-Active-16a34a?style=flat&logo=githubactions&logoColor=white" alt="CI/CD badge" /></a>
-        <img src="https://img.shields.io/badge/Release-0.114.1-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release badge" />
+        <img src="https://img.shields.io/badge/Release-0.115.0-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release badge" />
         <a href="#license"><img src="https://img.shields.io/badge/License-Apache--2.0-0f766e?style=flat&logo=apache&logoColor=white" alt="License badge" /></a>
       </td>
     </tr>
@@ -207,7 +207,7 @@ ThreadOptions(
     sandbox_mode="workspace-write",
     working_directory="/path/to/project",
     skip_git_repo_check=True,
-    model_reasoning_effort="high",
+    model_reasoning_effort="none",
     model_instructions_file="/path/to/instructions.md",
     model_personality="friendly",
     max_threads=4,
@@ -222,7 +222,8 @@ ThreadOptions(
     connectors_enabled=True,
     responses_websockets_enabled=True,
     request_compression_enabled=True,
-    approval_policy="on-request",
+    approval_policy="granular",
+    approvals_reviewer="guardian_subagent",
     additional_directories=["../shared"],
     config_overrides={"analytics.enabled": True},
 )
@@ -233,7 +234,8 @@ Important mappings to the Codex CLI:
 - `working_directory` maps to `--cd`.
 - `additional_directories` maps to repeated `--add-dir`.
 - `skip_git_repo_check` maps to `--skip-git-repo-check`.
-- `model_reasoning_effort` maps to `--config model_reasoning_effort=...`.
+- `model_reasoning_effort` maps to `--config model_reasoning_effort=...`
+  (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`).
 - `model_instructions_file` maps to `--config model_instructions_file=...`.
 - `model_personality` maps to `--config model_personality=...`.
 - `max_threads` maps to `--config agents.max_threads=...`.
@@ -251,7 +253,10 @@ Important mappings to the Codex CLI:
 - `responses_websockets_enabled` maps to `--config features.responses_websockets=...`.
 - `request_compression_enabled` maps to `--config features.enable_request_compression=...`.
 - `feature_overrides` maps to `--config features.<key>=...` (explicit options take precedence).
-- `approval_policy` maps to `--config approval_policy=...`.
+- `approval_policy` maps to `--config approval_policy=...`
+  (`never`, `on-request`, `on-failure`, `untrusted`, `granular`).
+- `approvals_reviewer` maps to `--config approvals_reviewer=...` for app-server-backed
+  approval routing (`user`, `guardian_subagent`).
 - `config_overrides` maps to repeated `--config key=value` entries.
 
 Note: `skills_enabled` is deprecated in Codex 0.80+ (skills are always enabled).
@@ -319,7 +324,9 @@ The SDK also exposes helpers for most app-server endpoints:
 - Turns/review: `turn_start`, `turn_steer`, `turn_interrupt`, `review_start`, `turn_session`
 - Models: `model_list`, `experimental_feature_list`
 - Collaboration modes: `collaboration_mode_list` (experimental)
-- Plugins: `plugin_list`, `plugin_install`, `plugin_uninstall`
+- Plugins: `plugin_list`, `plugin_read`, `plugin_install`, `plugin_uninstall`
+- Filesystem (experimental): `fs_copy`, `fs_create_directory`, `fs_get_metadata`,
+  `fs_read_directory`, `fs_read_file`, `fs_remove`, `fs_write_file`
 - One-off commands: `command_exec`, `command_exec_write`, `command_exec_resize`,
   `command_exec_terminate`
 - MCP auth/status: `mcp_server_oauth_login`, `mcp_server_refresh`, `mcp_server_status_list`
@@ -340,6 +347,10 @@ Note: some endpoints and fields are gated behind an experimental capability; set
 
 `thread_list` supports `archived`, `sort_key`, and `source_kinds` filters, and `config_read` accepts an optional `cwd`
 to compute the effective layered config for a specific working directory.
+
+Codex 0.115.0 also adds experimental granular approval routing (`approval_policy="granular"`)
+and guardian reviewer selection via `approvals_reviewer`; the app-server helpers pass those
+through with the existing snake_case to camelCase normalization.
 
 ### Observability (OTEL) and notify
 
@@ -612,7 +623,8 @@ The SDK forwards sandbox and approval controls directly to `codex exec`.
 Additional controls:
 - `working_directory`: restricts where the CLI starts and what it can access.
 - `additional_directories`: allowlist extra folders when using `workspace-write`.
-- `approval_policy`: `never`, `on-request`, `on-failure`, `untrusted`.
+- `approval_policy`: `never`, `on-request`, `on-failure`, `untrusted`, `granular`.
+- `approvals_reviewer`: `user`, `guardian_subagent` for app-server approval routing.
 - `network_access_enabled`: toggles network access in workspace-write sandbox.
 - `web_search_mode`: toggles web search (`disabled`, `cached`, `live`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "codex-sdk-python"
-version = "0.114.1"
+version = "0.115.0"
 description = "Python SDK for the Codex CLI agent with async threads, streaming events, and structured outputs"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/codex_sdk/__init__.py
+++ b/src/codex_sdk/__init__.py
@@ -64,6 +64,7 @@ from .items import (
 )
 from .options import (
     ApprovalMode,
+    ApprovalsReviewer,
     CodexOptions,
     ModelPersonality,
     ModelReasoningEffort,
@@ -82,7 +83,7 @@ from .thread import (
     Turn,
 )
 
-__version__ = "0.114.1"
+__version__ = "0.115.0"
 
 __all__ = [
     "AbortController",
@@ -141,6 +142,7 @@ __all__ = [
     "ThreadOptions",
     "TurnOptions",
     "ApprovalMode",
+    "ApprovalsReviewer",
     "SandboxMode",
     "ModelReasoningEffort",
     "ModelPersonality",

--- a/src/codex_sdk/app_server.py
+++ b/src/codex_sdk/app_server.py
@@ -1065,9 +1065,87 @@ class AppServerClient:
         }
         return await self._request_dict("plugin/install", _coerce_keys(params))
 
+    async def plugin_read(
+        self,
+        *,
+        marketplace_path: Union[str, Path],
+        plugin_name: str,
+    ) -> Dict[str, Any]:
+        """Read metadata for a plugin from a discovered marketplace."""
+        params = {
+            "marketplace_path": str(marketplace_path),
+            "plugin_name": plugin_name,
+        }
+        return await self._request_dict("plugin/read", _coerce_keys(params))
+
     async def plugin_uninstall(self, *, plugin_id: str) -> Dict[str, Any]:
         """Uninstall a previously installed plugin."""
         return await self._request_dict("plugin/uninstall", {"pluginId": plugin_id})
+
+    async def fs_copy(
+        self,
+        *,
+        source_path: Union[str, Path],
+        destination_path: Union[str, Path],
+        recursive: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Copy a file or directory via the experimental filesystem API."""
+        params: Dict[str, Any] = {
+            "source_path": str(source_path),
+            "destination_path": str(destination_path),
+        }
+        if recursive is not None:
+            params["recursive"] = recursive
+        return await self._request_dict("fs/copy", _coerce_keys(params))
+
+    async def fs_create_directory(
+        self,
+        *,
+        path: Union[str, Path],
+        recursive: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Create a directory via the experimental filesystem API."""
+        params: Dict[str, Any] = {"path": str(path)}
+        if recursive is not None:
+            params["recursive"] = recursive
+        return await self._request_dict("fs/createDirectory", _coerce_keys(params))
+
+    async def fs_get_metadata(self, *, path: Union[str, Path]) -> Dict[str, Any]:
+        """Read filesystem metadata for a path via the experimental filesystem API."""
+        return await self._request_dict("fs/getMetadata", {"path": str(path)})
+
+    async def fs_read_directory(self, *, path: Union[str, Path]) -> Dict[str, Any]:
+        """List a directory via the experimental filesystem API."""
+        return await self._request_dict("fs/readDirectory", {"path": str(path)})
+
+    async def fs_read_file(self, *, path: Union[str, Path]) -> Dict[str, Any]:
+        """Read a file via the experimental filesystem API."""
+        return await self._request_dict("fs/readFile", {"path": str(path)})
+
+    async def fs_remove(
+        self,
+        *,
+        path: Union[str, Path],
+        force: Optional[bool] = None,
+        recursive: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Remove a file or directory via the experimental filesystem API."""
+        params: Dict[str, Any] = {"path": str(path)}
+        if force is not None:
+            params["force"] = force
+        if recursive is not None:
+            params["recursive"] = recursive
+        return await self._request_dict("fs/remove", _coerce_keys(params))
+
+    async def fs_write_file(
+        self,
+        *,
+        path: Union[str, Path],
+        data_base64: str,
+    ) -> Dict[str, Any]:
+        """Write a file via the experimental filesystem API."""
+        params = {"path": str(path), "data_base64": data_base64}
+        return await self._request_dict("fs/writeFile", _coerce_keys(params))
 
     async def command_exec(
         self,

--- a/src/codex_sdk/exec.py
+++ b/src/codex_sdk/exec.py
@@ -29,6 +29,7 @@ from .config_overrides import encode_config_overrides
 from .exceptions import CodexAbortError, CodexCLIError, CodexError
 from .options import (
     ApprovalMode,
+    ApprovalsReviewer,
     ModelPersonality,
     ModelReasoningEffort,
     SandboxMode,
@@ -76,6 +77,7 @@ class CodexExecArgs:
     request_compression_enabled: Optional[bool] = None
     feature_overrides: Optional[Mapping[str, bool]] = None
     approval_policy: Optional[ApprovalMode] = None
+    approvals_reviewer: Optional[ApprovalsReviewer] = None
     signal: Optional[AbortSignal] = None
     config_overrides: Optional[Mapping[str, Any]] = None
 
@@ -324,6 +326,11 @@ class CodexExec:
         if args.approval_policy:
             command_args.extend(
                 ["--config", f'approval_policy="{args.approval_policy}"']
+            )
+
+        if args.approvals_reviewer:
+            command_args.extend(
+                ["--config", f'approvals_reviewer="{args.approvals_reviewer}"']
             )
 
         if args.thread_id:

--- a/src/codex_sdk/integrations/pydantic_ai_model.py
+++ b/src/codex_sdk/integrations/pydantic_ai_model.py
@@ -931,6 +931,8 @@ class CodexModel(Model):
             params["feature_overrides"] = _jsonable(options.feature_overrides)
         if options.approval_policy is not None:
             params["approval_policy"] = options.approval_policy
+        if options.approvals_reviewer is not None:
+            params["approvals_reviewer"] = options.approvals_reviewer
         if options.additional_directories is not None:
             params["additional_directories"] = list(options.additional_directories)
         if options.config_overrides is not None:

--- a/src/codex_sdk/items.py
+++ b/src/codex_sdk/items.py
@@ -23,12 +23,19 @@ McpToolCallStatus = Literal["in_progress", "completed", "failed"]
 CollabToolCallStatus = Literal["in_progress", "completed", "failed"]
 
 # Supported collaboration tools
-CollabTool = Literal["spawn_agent", "send_input", "wait", "close_agent"]
+CollabTool = Literal[
+    "spawn_agent",
+    "send_input",
+    "wait",
+    "wait_agent",
+    "close_agent",
+]
 
 # The status of a collaboration agent
 CollabAgentStatus = Literal[
     "pending_init",
     "running",
+    "interrupted",
     "completed",
     "errored",
     "shutdown",
@@ -154,6 +161,8 @@ class CollabToolCallItem:
     prompt: Optional[str]
     agents_states: Mapping[str, CollabAgentState]
     status: CollabToolCallStatus
+    model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
 
 
 @dataclass

--- a/src/codex_sdk/items.py
+++ b/src/codex_sdk/items.py
@@ -7,6 +7,8 @@ Based on item types from codex-rs/exec/src/exec_events.rs
 from dataclasses import dataclass
 from typing import Any, List, Literal, Mapping, Optional, Union
 
+from .options import ModelReasoningEffort
+
 # The status of a command execution
 CommandExecutionStatus = Literal["in_progress", "completed", "failed", "declined"]
 
@@ -162,7 +164,7 @@ class CollabToolCallItem:
     agents_states: Mapping[str, CollabAgentState]
     status: CollabToolCallStatus
     model: Optional[str] = None
-    reasoning_effort: Optional[str] = None
+    reasoning_effort: Optional[ModelReasoningEffort] = None
 
 
 @dataclass

--- a/src/codex_sdk/options.py
+++ b/src/codex_sdk/options.py
@@ -8,11 +8,12 @@ from typing import Any, List, Literal, Mapping, Optional, Union
 
 from .abort import AbortSignal
 
-ApprovalMode = Literal["never", "on-request", "on-failure", "untrusted"]
+ApprovalMode = Literal["never", "on-request", "on-failure", "untrusted", "granular"]
+ApprovalsReviewer = Literal["user", "guardian_subagent"]
 
 SandboxMode = Literal["read-only", "workspace-write", "danger-full-access"]
 
-ModelReasoningEffort = Literal["minimal", "low", "medium", "high", "xhigh"]
+ModelReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
 WebSearchMode = Literal["disabled", "cached", "live"]
 ModelPersonality = Literal["friendly", "pragmatic", "none"]
 
@@ -76,7 +77,10 @@ class ThreadOptions:
         responses_websockets_enabled: Enable/disable responses websocket transport.
         request_compression_enabled: Enable/disable request body compression.
         feature_overrides: Arbitrary feature flag overrides (key -> bool).
-        approval_policy: Approval policy for tool execution.
+        approval_policy: Approval policy for tool execution, including experimental
+            granular approval routing.
+        approvals_reviewer: Optional approval reviewer routing target for app-server
+            approval flows.
         additional_directories: Additional directories to add to the sandbox.
         config_overrides: Optional config overrides passed as `--config key=value` for this
             thread's invocations. Values are encoded as TOML literals.
@@ -153,6 +157,9 @@ class ThreadOptions:
 
     # Approval policy for tool execution
     approval_policy: Optional[ApprovalMode] = None
+
+    # Optional approval reviewer routing target
+    approvals_reviewer: Optional[ApprovalsReviewer] = None
 
     # Additional directories to add to the sandbox
     additional_directories: Optional[List[str]] = None

--- a/src/codex_sdk/thread.py
+++ b/src/codex_sdk/thread.py
@@ -39,10 +39,11 @@ from .items import (
     TodoListItem,
     WebSearchItem,
 )
-from .options import CodexOptions, ThreadOptions, TurnOptions
+from .options import CodexOptions, ModelReasoningEffort, ThreadOptions, TurnOptions
 from .telemetry import span
 
 T = TypeVar("T")
+_MODEL_REASONING_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
 
 
 @dataclass
@@ -530,6 +531,8 @@ class Thread:
                     if isinstance(alt_reasoning_effort, str)
                     else None
                 )
+            if reasoning_effort not in _MODEL_REASONING_EFFORTS:
+                reasoning_effort = None
             return CollabToolCallItem(
                 id=data["id"],
                 type="collab_tool_call",
@@ -538,7 +541,7 @@ class Thread:
                 receiver_thread_ids=receiver_thread_ids,
                 prompt=prompt if isinstance(prompt, str) else None,
                 model=model if isinstance(model, str) else None,
-                reasoning_effort=reasoning_effort,
+                reasoning_effort=cast(Optional[ModelReasoningEffort], reasoning_effort),
                 agents_states=agents_states,
                 status=data["status"],
             )

--- a/src/codex_sdk/thread.py
+++ b/src/codex_sdk/thread.py
@@ -337,6 +337,7 @@ class Thread:
                     request_compression_enabled=self._thread_options.request_compression_enabled,
                     feature_overrides=self._thread_options.feature_overrides,
                     approval_policy=self._thread_options.approval_policy,
+                    approvals_reviewer=self._thread_options.approvals_reviewer,
                     config_overrides=merge_config_overrides(
                         self._options.config_overrides,
                         self._thread_options.config_overrides,
@@ -520,6 +521,15 @@ class Thread:
                     )
 
             prompt = data.get("prompt")
+            model = data.get("model")
+            reasoning_effort = data.get("reasoning_effort")
+            if not isinstance(reasoning_effort, str):
+                alt_reasoning_effort = data.get("reasoningEffort")
+                reasoning_effort = (
+                    alt_reasoning_effort
+                    if isinstance(alt_reasoning_effort, str)
+                    else None
+                )
             return CollabToolCallItem(
                 id=data["id"],
                 type="collab_tool_call",
@@ -527,6 +537,8 @@ class Thread:
                 sender_thread_id=data["sender_thread_id"],
                 receiver_thread_ids=receiver_thread_ids,
                 prompt=prompt if isinstance(prompt, str) else None,
+                model=model if isinstance(model, str) else None,
+                reasoning_effort=reasoning_effort,
                 agents_states=agents_states,
                 status=data["status"],
             )

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -630,6 +630,19 @@ async def test_app_server_methods_and_input_normalization(
     }
 
     task = asyncio.create_task(
+        client.fs_copy(
+            source_path=tmp_path / "source.txt",
+            destination_path=tmp_path / "dest.txt",
+        )
+    )
+    _, payload = await expect_request(task, "fs/copy", {})
+    assert payload["params"] == {
+        "sourcePath": str(tmp_path / "source.txt"),
+        "destinationPath": str(tmp_path / "dest.txt"),
+    }
+    assert "recursive" not in payload["params"]
+
+    task = asyncio.create_task(
         client.fs_create_directory(path=tmp_path / "nested", recursive=True)
     )
     _, payload = await expect_request(task, "fs/createDirectory", {})
@@ -637,6 +650,11 @@ async def test_app_server_methods_and_input_normalization(
         "path": str(tmp_path / "nested"),
         "recursive": True,
     }
+
+    task = asyncio.create_task(client.fs_create_directory(path=tmp_path / "nested"))
+    _, payload = await expect_request(task, "fs/createDirectory", {})
+    assert payload["params"] == {"path": str(tmp_path / "nested")}
+    assert "recursive" not in payload["params"]
 
     task = asyncio.create_task(client.fs_get_metadata(path=tmp_path / "source.txt"))
     _, payload = await expect_request(
@@ -669,6 +687,12 @@ async def test_app_server_methods_and_input_normalization(
         "force": True,
         "recursive": False,
     }
+
+    task = asyncio.create_task(client.fs_remove(path=tmp_path / "source.txt"))
+    _, payload = await expect_request(task, "fs/remove", {})
+    assert payload["params"] == {"path": str(tmp_path / "source.txt")}
+    assert "force" not in payload["params"]
+    assert "recursive" not in payload["params"]
 
     task = asyncio.create_task(
         client.fs_write_file(path=tmp_path / "source.txt", data_base64="aGk=")

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -599,9 +599,85 @@ async def test_app_server_methods_and_input_normalization(
         "pluginName": "test-plugin",
     }
 
+    task = asyncio.create_task(
+        client.plugin_read(
+            marketplace_path=tmp_path / "marketplace",
+            plugin_name="test-plugin",
+        )
+    )
+    _, payload = await expect_request(task, "plugin/read", {"plugin": {}})
+    assert payload["params"] == {
+        "marketplacePath": str(tmp_path / "marketplace"),
+        "pluginName": "test-plugin",
+    }
+
     task = asyncio.create_task(client.plugin_uninstall(plugin_id="plugin_1"))
     _, payload = await expect_request(task, "plugin/uninstall", {"ok": True})
     assert payload["params"] == {"pluginId": "plugin_1"}
+
+    task = asyncio.create_task(
+        client.fs_copy(
+            source_path=tmp_path / "source.txt",
+            destination_path=tmp_path / "dest.txt",
+            recursive=False,
+        )
+    )
+    _, payload = await expect_request(task, "fs/copy", {})
+    assert payload["params"] == {
+        "sourcePath": str(tmp_path / "source.txt"),
+        "destinationPath": str(tmp_path / "dest.txt"),
+        "recursive": False,
+    }
+
+    task = asyncio.create_task(
+        client.fs_create_directory(path=tmp_path / "nested", recursive=True)
+    )
+    _, payload = await expect_request(task, "fs/createDirectory", {})
+    assert payload["params"] == {
+        "path": str(tmp_path / "nested"),
+        "recursive": True,
+    }
+
+    task = asyncio.create_task(client.fs_get_metadata(path=tmp_path / "source.txt"))
+    _, payload = await expect_request(
+        task,
+        "fs/getMetadata",
+        {
+            "isDirectory": False,
+            "isFile": True,
+            "sizeBytes": 2,
+            "createdAtMs": 1,
+            "modifiedAtMs": 2,
+        },
+    )
+    assert payload["params"] == {"path": str(tmp_path / "source.txt")}
+
+    task = asyncio.create_task(client.fs_read_directory(path=tmp_path))
+    _, payload = await expect_request(task, "fs/readDirectory", {"entries": []})
+    assert payload["params"] == {"path": str(tmp_path)}
+
+    task = asyncio.create_task(client.fs_read_file(path=tmp_path / "source.txt"))
+    _, payload = await expect_request(task, "fs/readFile", {"dataBase64": "aGk="})
+    assert payload["params"] == {"path": str(tmp_path / "source.txt")}
+
+    task = asyncio.create_task(
+        client.fs_remove(path=tmp_path / "source.txt", force=True, recursive=False)
+    )
+    _, payload = await expect_request(task, "fs/remove", {})
+    assert payload["params"] == {
+        "path": str(tmp_path / "source.txt"),
+        "force": True,
+        "recursive": False,
+    }
+
+    task = asyncio.create_task(
+        client.fs_write_file(path=tmp_path / "source.txt", data_base64="aGk=")
+    )
+    _, payload = await expect_request(task, "fs/writeFile", {})
+    assert payload["params"] == {
+        "path": str(tmp_path / "source.txt"),
+        "dataBase64": "aGk=",
+    }
 
     task = asyncio.create_task(
         client.command_exec(

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -364,7 +364,7 @@ class TestOptions:
             sandbox_mode="read-only",
             working_directory="/tmp",
             skip_git_repo_check=True,
-            model_reasoning_effort="high",
+            model_reasoning_effort="none",
             model_instructions_file="/tmp/instructions.md",
             model_personality="friendly",
             max_threads=3,
@@ -383,7 +383,8 @@ class TestOptions:
             responses_websockets_enabled=True,
             request_compression_enabled=True,
             feature_overrides={"web_search_cached": False},
-            approval_policy="on-request",
+            approval_policy="granular",
+            approvals_reviewer="guardian_subagent",
             additional_directories=["../backend"],
         )
 
@@ -391,7 +392,7 @@ class TestOptions:
         assert options.sandbox_mode == "read-only"
         assert options.working_directory == "/tmp"
         assert options.skip_git_repo_check is True
-        assert options.model_reasoning_effort == "high"
+        assert options.model_reasoning_effort == "none"
         assert options.model_instructions_file == "/tmp/instructions.md"
         assert options.model_personality == "friendly"
         assert options.max_threads == 3
@@ -410,7 +411,8 @@ class TestOptions:
         assert options.responses_websockets_enabled is True
         assert options.request_compression_enabled is True
         assert options.feature_overrides == {"web_search_cached": False}
-        assert options.approval_policy == "on-request"
+        assert options.approval_policy == "granular"
+        assert options.approvals_reviewer == "guardian_subagent"
         assert options.additional_directories == ["../backend"]
 
     def test_turn_options(self):

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -287,7 +287,7 @@ async def test_exec_passes_config_and_repeated_flags(
     args = CodexExecArgs(
         input="hello",
         thread_id="thread-123",
-        model_reasoning_effort="high",
+        model_reasoning_effort="none",
         model_instructions_file=instructions_path,
         model_personality="pragmatic",
         max_threads=5,
@@ -303,7 +303,8 @@ async def test_exec_passes_config_and_repeated_flags(
         connectors_enabled=True,
         responses_websockets_enabled=False,
         request_compression_enabled=False,
-        approval_policy="on-request",
+        approval_policy="granular",
+        approvals_reviewer="guardian_subagent",
         additional_directories=["../backend", "/tmp/shared"],
         images=["/tmp/one.png", "/tmp/two.jpg"],
     )
@@ -314,7 +315,7 @@ async def test_exec_passes_config_and_repeated_flags(
     cmd_list = captured["cmd"]
     assert cmd_list[:2] == ["codex-binary", "exec"]
     assert "--config" in cmd_list
-    assert 'model_reasoning_effort="high"' in cmd_list
+    assert 'model_reasoning_effort="none"' in cmd_list
     assert f'model_instructions_file="{instructions_path}"' in cmd_list
     assert 'model_personality="pragmatic"' in cmd_list
     assert "agents.max_threads=5" in cmd_list
@@ -329,7 +330,8 @@ async def test_exec_passes_config_and_repeated_flags(
     assert "features.connectors=true" in cmd_list
     assert "features.responses_websockets=false" in cmd_list
     assert "features.enable_request_compression=false" in cmd_list
-    assert 'approval_policy="on-request"' in cmd_list
+    assert 'approval_policy="granular"' in cmd_list
+    assert 'approvals_reviewer="guardian_subagent"' in cmd_list
 
     add_dir_values = [
         cmd_list[i + 1] for i, v in enumerate(cmd_list[:-1]) if v == "--add-dir"

--- a/tests/test_pydantic_ai_model.py
+++ b/tests/test_pydantic_ai_model.py
@@ -1319,7 +1319,7 @@ async def test_codex_model_thread_start_params_include_extended_options():
 
 
 @pytest.mark.asyncio
-async def test_codex_model_thread_start_params_omit_unset_optional_options():
+async def test_codex_model_thread_start_params_omit_unset_optional_options() -> None:
     app = FakeAppServerClient(
         notifications=[],
         final_turn={

--- a/tests/test_pydantic_ai_model.py
+++ b/tests/test_pydantic_ai_model.py
@@ -172,7 +172,8 @@ def test_codex_model_does_not_override_explicit_thread_options() -> None:
     thread_options = importlib.import_module("codex_sdk.options").ThreadOptions(
         skip_git_repo_check=False,
         sandbox_mode="workspace-write",
-        approval_policy="on-request",
+        approval_policy="granular",
+        approvals_reviewer="guardian_subagent",
         web_search_mode="live",
         network_access_enabled=True,
     )
@@ -183,7 +184,8 @@ def test_codex_model_does_not_override_explicit_thread_options() -> None:
     assert model.model_name == "codex"
     assert thread_options.skip_git_repo_check is False
     assert thread_options.sandbox_mode == "workspace-write"
-    assert thread_options.approval_policy == "on-request"
+    assert thread_options.approval_policy == "granular"
+    assert thread_options.approvals_reviewer == "guardian_subagent"
     assert thread_options.web_search_mode == "live"
     assert thread_options.network_access_enabled is True
 
@@ -1247,6 +1249,7 @@ async def test_codex_model_thread_start_params_include_extended_options():
         sandbox_mode="workspace-write",
         working_directory="/tmp",
         skip_git_repo_check=False,
+        model_reasoning_effort="none",
         model_instructions_file="/tmp/instructions.md",
         model_personality="friendly",
         max_threads=3,
@@ -1264,7 +1267,8 @@ async def test_codex_model_thread_start_params_include_extended_options():
         responses_websockets_enabled=True,
         request_compression_enabled=True,
         feature_overrides={"experimental": True},
-        approval_policy="on-request",
+        approval_policy="granular",
+        approvals_reviewer="guardian_subagent",
         additional_directories=["/tmp/a", "/tmp/b"],
         config_overrides={"feature": "on"},
     )
@@ -1290,6 +1294,7 @@ async def test_codex_model_thread_start_params_include_extended_options():
     assert sent["cwd"] == "/tmp"
     assert sent["sandbox_mode"] == "workspace-write"
     assert sent["skip_git_repo_check"] is False
+    assert sent["model_reasoning_effort"] == "none"
     assert sent["model_instructions_file"] == "/tmp/instructions.md"
     assert sent["model_personality"] == "friendly"
     assert sent["max_threads"] == 3
@@ -1307,9 +1312,30 @@ async def test_codex_model_thread_start_params_include_extended_options():
     assert sent["responses_websockets_enabled"] is True
     assert sent["request_compression_enabled"] is True
     assert sent["feature_overrides"] == {"experimental": True}
-    assert sent["approval_policy"] == "on-request"
+    assert sent["approval_policy"] == "granular"
+    assert sent["approvals_reviewer"] == "guardian_subagent"
     assert sent["additional_directories"] == ["/tmp/a", "/tmp/b"]
     assert sent["config_overrides"] == {"feature": "on"}
+
+
+@pytest.mark.asyncio
+async def test_codex_model_thread_start_params_omit_unset_optional_options():
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-omit",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": "ok",
+        },
+    )
+    model = CodexModel(app_server=app, thread_options=ThreadOptions())
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    await model.request([ModelRequest(parts=[UserPromptPart("omit")])], None, params)
+
+    sent = app.thread_start_calls[0]
+    assert "approvals_reviewer" not in sent
+    assert "model_reasoning_effort" not in sent
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -314,12 +314,14 @@ def test_parse_item_branches():
         {
             "id": "col",
             "type": "collab_tool_call",
-            "tool": "spawn_agent",
+            "tool": "wait_agent",
             "sender_thread_id": "thr_1",
             "receiver_thread_ids": ["thr_2", "thr_3"],
             "prompt": "do it",
+            "model": "gpt-5.4",
+            "reasoning_effort": "high",
             "agents_states": {
-                "thr_2": {"status": "running"},
+                "thr_2": {"status": "interrupted"},
                 "thr_3": {"status": "completed", "message": "ok"},
             },
             "status": "in_progress",
@@ -328,12 +330,14 @@ def test_parse_item_branches():
     assert collab_item == CollabToolCallItem(
         id="col",
         type="collab_tool_call",
-        tool="spawn_agent",
+        tool="wait_agent",
         sender_thread_id="thr_1",
         receiver_thread_ids=["thr_2", "thr_3"],
         prompt="do it",
+        model="gpt-5.4",
+        reasoning_effort="high",
         agents_states={
-            "thr_2": CollabAgentState(status="running", message=None),
+            "thr_2": CollabAgentState(status="interrupted", message=None),
             "thr_3": CollabAgentState(status="completed", message="ok"),
         },
         status="in_progress",
@@ -492,6 +496,8 @@ async def test_turn_filters_work():
                 sender_thread_id="thr_1",
                 receiver_thread_ids=["thr_2"],
                 prompt=None,
+                model=None,
+                reasoning_effort=None,
                 agents_states={},
                 status="completed",
             ),
@@ -794,7 +800,30 @@ def test_parse_item_handles_collab_tool_call_with_missing_collections() -> None:
     assert item.type == "collab_tool_call"
     assert item.receiver_thread_ids == []
     assert item.prompt is None
+    assert item.model is None
+    assert item.reasoning_effort is None
     assert item.agents_states == {}
+
+
+def test_parse_item_handles_collab_tool_call_camel_case_reasoning_effort() -> None:
+    thread = Thread(FakeExecNoop(), CodexOptions(), ThreadOptions())
+    item = thread._parse_item(
+        {
+            "id": "item-3",
+            "type": "collab_tool_call",
+            "tool": "spawn_agent",
+            "sender_thread_id": "t0",
+            "receiver_thread_ids": ["t1"],
+            "prompt": "run it",
+            "model": "gpt-5.4",
+            "reasoningEffort": "medium",
+            "agents_states": {},
+            "status": "completed",
+        }
+    )
+    assert item.type == "collab_tool_call"
+    assert item.model == "gpt-5.4"
+    assert item.reasoning_effort == "medium"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -769,7 +769,7 @@ wheels = [
 
 [[package]]
 name = "codex-sdk-python"
-version = "0.114.1"
+version = "0.115.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Sync the Python SDK to the Codex 0.115.0 release line.

This brings the SDK back into parity with the current CLI and app-server surface by adding the newly exposed filesystem RPC helpers, `plugin_read`, updated collaboration item parsing for spawned-agent metadata and `wait_agent`, and the missing typed thread-start options for granular approvals and `model_reasoning_effort="none"`.

The lower-level app-server wrapper needed to follow upstream closely, but the typed SDK and PydanticAI integration had fallen slightly behind the release contract. This change closes that gap and updates the release metadata and docs to match the shipped behavior.

Vendor binaries were refreshed locally for validation only and are intentionally left out of the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release v0.115.0

* **New Features**
  * Experimental app-server filesystem operations (copy, mkdir, read/write, metadata, remove).
  * Plugin metadata read from marketplaces.
  * Introduced granular approval routing with guardian reviewer support.

* **Updates**
  * Default model reasoning effort set to "none".
  * Thread/tool payloads now include optional model and reasoning_effort fields.
  * Agent lifecycle expanded with new statuses including "interrupted" and "not_found".
  * wait_agent tool name accepted.

* **Documentation**
  * Updated README, changelog, and observability notes for 0.115.0.

* **Tests**
  * Added/updated tests covering filesystem, plugin_read, approvals_reviewer, and new thread fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->