### PR TITLE
docs(readme): refresh model examples and app-server diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,7 +754,11 @@ If Logfire is missing or not initialized, the span context manager is a no-op.
 <a id="acheature"></a>
 ## ![Architecture](https://img.shields.io/badge/Architecture-Stack%20map-1f2937?style=for-the-badge&logo=serverless&logoColor=white)
 
-### System components
+### Transport split
+
+The SDK still ships two separate transports. The Thread API runs through
+`codex exec`, while app-server-backed integrations use `codex app-server`
+directly and do not fall back to `codex exec --experimental-json`.
 
 ```mermaid
 flowchart LR
@@ -764,15 +768,15 @@ flowchart LR
     M[CodexModel / AppServerClient]
   end
 
-  subgraph SDK[Codex SDK]
-    C[Codex]
+  subgraph ThreadTransport[Thread transport]
+    C[Codex / Thread]
     E[CodexExec]
     P[Event Parser]
-    A[App-server client]
+    X["codex exec --experimental-json"]
   end
 
-  subgraph CLI[Bundled Codex CLI]
-    X["codex exec --experimental-json"]
+  subgraph AppServerTransport[App-server transport]
+    A[App-server client]
     S["codex app-server"]
   end
 
@@ -823,7 +827,14 @@ sequenceDiagram
   participant Tools as User Tools
 
   Agent->>Model: request(messages, tools)
-  Model->>App: thread_start / thread_resume
+  alt no cached thread id
+    Model->>App: thread_start(...)
+    App->>CLI: thread/start over JSON-RPC
+    CLI-->>App: thread metadata
+    App-->>Model: thread.id
+  else cached thread id
+    Model-->>Model: reuse cached thread id
+  end
   Model->>App: turn_session(input, approvals)
   App->>CLI: turn/start over JSON-RPC
   CLI-->>App: item/updated + turn/completed

--- a/README.md
+++ b/README.md
@@ -237,10 +237,11 @@ Important mappings to the Codex CLI:
 - `additional_directories` maps to repeated `--add-dir`.
 - `skip_git_repo_check` maps to `--skip-git-repo-check`.
 - `model_reasoning_effort` maps to `--config model_reasoning_effort=...`.
-  The typed SDK accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`,
-  but the presets exposed by Codex depend on the selected model/provider.
-  Current frontier coding models typically expose `low`, `medium`, `high`,
-  `xhigh`, while `gpt-5.1-codex-mini` exposes `medium` and `high`.
+  Typed SDK values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
+  In Codex itself, the presets exposed for `--config model_reasoning_effort=...`
+  vary by the selected model/provider.
+  For example, current frontier coding models typically expose `low`, `medium`,
+  `high`, `xhigh`, while `gpt-5.1-codex-mini` exposes `medium` and `high`.
 - `model_instructions_file` maps to `--config model_instructions_file=...`.
 - `model_personality` maps to `--config model_personality=...`.
 - `max_threads` maps to `--config agents.max_threads=...`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ![Codex SDK Python](https://img.shields.io/badge/Codex%20SDK-Python-1D4ED8?style=for-the-badge&logo=python&logoColor=white)
 
-Embed the Codex agent in Python workflows. This SDK wraps the bundled `codex` CLI, streams JSONL events over stdin/stdout, and exposes structured, typed results.
+Embed the Codex agent in Python workflows. This SDK supports both the `codex exec`
+JSONL path and the persistent app-server JSON-RPC path, and exposes structured,
+typed results for each.
 
 <div align="left">
   <table>
@@ -97,7 +99,7 @@ from codex_sdk import AppServerClient, AppServerOptions, ApprovalDecisions
 
 async def main() -> None:
     async with AppServerClient(AppServerOptions()) as app:
-        thread = await app.thread_start(model="gpt-5-codex-high", cwd=".")
+        thread = await app.thread_start(model="gpt-5.4", cwd=".")
         thread_id = thread["thread"]["id"]
         session = await app.turn_session(
             thread_id,
@@ -203,11 +205,11 @@ codex = Codex(
 from codex_sdk import ThreadOptions
 
 ThreadOptions(
-    model="gpt-5-codex-high",
+    model="gpt-5.4",
     sandbox_mode="workspace-write",
     working_directory="/path/to/project",
     skip_git_repo_check=True,
-    model_reasoning_effort="none",
+    model_reasoning_effort="medium",
     model_instructions_file="/path/to/instructions.md",
     model_personality="friendly",
     max_threads=4,
@@ -234,8 +236,11 @@ Important mappings to the Codex CLI:
 - `working_directory` maps to `--cd`.
 - `additional_directories` maps to repeated `--add-dir`.
 - `skip_git_repo_check` maps to `--skip-git-repo-check`.
-- `model_reasoning_effort` maps to `--config model_reasoning_effort=...`
-  (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`).
+- `model_reasoning_effort` maps to `--config model_reasoning_effort=...`.
+  The typed SDK accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`,
+  but the presets exposed by Codex depend on the selected model/provider.
+  Current frontier coding models typically expose `low`, `medium`, `high`,
+  `xhigh`, while `gpt-5.1-codex-mini` exposes `medium` and `high`.
 - `model_instructions_file` maps to `--config model_instructions_file=...`.
 - `model_personality` maps to `--config model_personality=...`.
 - `max_threads` maps to `--config agents.max_threads=...`.
@@ -287,7 +292,7 @@ from codex_sdk import AppServerClient, AppServerOptions
 
 async def main() -> None:
     async with AppServerClient(AppServerOptions()) as app:
-        thread = await app.thread_start(model="gpt-5-codex-high", cwd=".")
+        thread = await app.thread_start(model="gpt-5.4", cwd=".")
         thread_id = thread["thread"]["id"]
         await app.turn_start(
             thread_id,
@@ -755,25 +760,32 @@ flowchart LR
   subgraph App[Your Python App]
     U[User Code]
     T[Thread API]
+    M[CodexModel / AppServerClient]
   end
 
   subgraph SDK[Codex SDK]
     C[Codex]
     E[CodexExec]
     P[Event Parser]
+    A[App-server client]
   end
 
   subgraph CLI[Bundled Codex CLI]
     X["codex exec --experimental-json"]
+    S["codex app-server"]
   end
 
   FS[(Filesystem)]
   NET[(Network)]
 
   U --> T --> C --> E --> X
+  U --> M --> A --> S
   X -->|JSONL events| P --> T
+  S -->|JSON-RPC notifications| A --> M
   X --> FS
   X --> NET
+  S --> FS
+  S --> NET
 ```
 
 ### Streaming event lifecycle
@@ -805,21 +817,22 @@ sequenceDiagram
 sequenceDiagram
   participant Agent as PydanticAI Agent
   participant Model as CodexModel
-  participant SDK as Codex SDK
-  participant CLI as codex exec
+  participant App as AppServerClient
+  participant CLI as codex app-server
   participant Tools as User Tools
 
   Agent->>Model: request(messages, tools)
-  Model->>SDK: start_thread + run_json(prompt, output_schema)
-  SDK->>CLI: codex exec --output-schema
-  CLI-->>SDK: JSON envelope {tool_calls, final}
-  SDK-->>Model: ParsedTurn
-  alt tool_calls present
-    Model-->>Agent: ToolCallPart(s)
+  Model->>App: thread_start / thread_resume
+  Model->>App: turn_session(input, approvals)
+  App->>CLI: turn/start over JSON-RPC
+  CLI-->>App: item/updated + turn/completed
+  App-->>Model: notifications + final turn
+  alt tool calls emitted
+    Model-->>Agent: ToolCallPart(s) / tool deltas
     Agent->>Tools: execute tool(s)
     Tools-->>Agent: results
   else final text allowed
-    Model-->>Agent: TextPart(final)
+    Model-->>Agent: TextPart(final) / text deltas
   end
 ```
 

--- a/examples/app_server_approvals.py
+++ b/examples/app_server_approvals.py
@@ -7,7 +7,7 @@ from codex_sdk import AppServerClient, AppServerOptions, CodexAppServerError
 
 async def main() -> None:
     async with AppServerClient(AppServerOptions()) as app:
-        start = await app.thread_start(model="gpt-5-codex-high", cwd=".")
+        start = await app.thread_start(model="gpt-5.4", cwd=".")
         thread_id = start["thread"]["id"]
 
         await app.turn_start(thread_id, "List the repo and explain the structure.")

--- a/examples/app_server_basic.py
+++ b/examples/app_server_basic.py
@@ -7,7 +7,7 @@ from codex_sdk import AppServerClient, AppServerOptions
 
 async def main() -> None:
     async with AppServerClient(AppServerOptions()) as app:
-        thread_resp = await app.thread_start(model="gpt-5-codex-high", cwd=".")
+        thread_resp = await app.thread_start(model="gpt-5.4", cwd=".")
         thread_id = thread_resp["thread"]["id"]
 
         await app.turn_start(

--- a/examples/app_server_fork.py
+++ b/examples/app_server_fork.py
@@ -7,7 +7,7 @@ from codex_sdk import AppServerClient, AppServerOptions
 
 async def main() -> None:
     async with AppServerClient(AppServerOptions()) as app:
-        start = await app.thread_start(model="gpt-5-codex-high", cwd=".")
+        start = await app.thread_start(model="gpt-5.4", cwd=".")
         thread_id = start["thread"]["id"]
 
         await app.turn_start(thread_id, "Write a short plan for refactoring.")

--- a/examples/app_server_skill_input.py
+++ b/examples/app_server_skill_input.py
@@ -7,7 +7,7 @@ from codex_sdk import AppServerClient, AppServerOptions
 
 async def main() -> None:
     async with AppServerClient(AppServerOptions()) as app:
-        start = await app.thread_start(model="gpt-5-codex-high", cwd=".")
+        start = await app.thread_start(model="gpt-5.4", cwd=".")
         thread_id = start["thread"]["id"]
 
         await app.turn_start(

--- a/examples/app_server_turn_session.py
+++ b/examples/app_server_turn_session.py
@@ -7,7 +7,7 @@ from codex_sdk import ApprovalDecisions, AppServerClient, AppServerOptions
 
 async def main() -> None:
     async with AppServerClient(AppServerOptions()) as app:
-        thread = await app.thread_start(model="gpt-5-codex-high", cwd=".")
+        thread = await app.thread_start(model="gpt-5.4", cwd=".")
         thread_id = thread["thread"]["id"]
 
         session = await app.turn_session(

--- a/examples/config_overrides.py
+++ b/examples/config_overrides.py
@@ -19,7 +19,7 @@ async def main() -> None:
             }
         )
     )
-    thread = codex.start_thread(ThreadOptions(model="gpt-5-codex-high"))
+    thread = codex.start_thread(ThreadOptions(model="gpt-5.4"))
     turn = await thread.run("Summarize the repository and suggest next steps.")
     print(turn.final_response)
 

--- a/examples/model_configuration_example.py
+++ b/examples/model_configuration_example.py
@@ -3,7 +3,7 @@
 Model Configuration and API Endpoints Example
 
 This example demonstrates how to:
-1. Use different Codex models (gpt-5-codex, gpt-5 variants)
+1. Use different current Codex model families and reasoning presets
 2. Configure OpenAI-compatible API endpoints
 3. Set up custom model providers
 4. Compare different model behaviors
@@ -20,15 +20,18 @@ async def test_different_models():
     print("TESTING DIFFERENT CODEX MODELS")
     print("=" * 60)
 
-    # Available models
+    # Representative models from the current Codex menu.
     models = [
-        ("gpt-5-codex", "low", "Fastest Codex model"),
-        ("gpt-5-codex", "medium", "Balanced Codex model"),
-        ("gpt-5-codex", "high", "Most capable Codex model (current default)"),
-        ("gpt-5", "minimal", "Fastest responses, limited reasoning"),
-        ("gpt-5", "low", "Balances speed with reasoning"),
-        ("gpt-5", "medium", "Default GPT-5, solid balance"),
-        ("gpt-5", "high", "Maximizes reasoning depth"),
+        ("gpt-5.4", "medium", "Latest frontier agentic coding model"),
+        ("gpt-5.4", "xhigh", "Latest frontier model with extra high reasoning"),
+        ("gpt-5.3-codex", "medium", "Frontier Codex-optimized coding model"),
+        ("gpt-5.3-codex", "xhigh", "Codex-optimized model with deeper reasoning"),
+        ("gpt-5.3-codex-spark", "high", "Ultra-fast coding model"),
+        (
+            "gpt-5.1-codex-mini",
+            "high",
+            "Cheaper codex model with max supported reasoning",
+        ),
     ]
 
     codex = Codex()
@@ -41,7 +44,8 @@ async def test_different_models():
 
         # Create thread with specific model
         thread_options = ThreadOptions(
-            model=f"{model}-{effort}",
+            model=model,
+            model_reasoning_effort=effort,
             sandbox_mode="danger-full-access",
             working_directory=".",
             skip_git_repo_check=True,
@@ -94,13 +98,13 @@ async def test_openai_compatible_endpoints():
         {
             "name": "OpenAI Direct",
             "base_url": "https://api.openai.com/v1",
-            "model": "gpt-4o",
+            "model": "gpt-5.4",
             "env_key": "OPENAI_API_KEY",
         },
         {
             "name": "Azure OpenAI",
             "base_url": "https://your-resource.openai.azure.com/openai",
-            "model": "gpt-4o",
+            "model": "gpt-5.4",
             "env_key": "AZURE_OPENAI_API_KEY",
         },
         {
@@ -132,7 +136,7 @@ async def test_openai_compatible_endpoints():
 # Example config.toml for OpenAI-compatible endpoints
 
 # Use a custom model provider
-model = "gpt-4o"
+model = "gpt-5.4"
 model_provider = "openai-direct"
 
 # Define custom model providers
@@ -172,11 +176,11 @@ async def test_model_comparison():
 
     # Test different models on the same task
     models_to_compare = [
-        "gpt-5-codex-low",
-        "gpt-5-codex-medium",
-        "gpt-5-codex-high",
-        "gpt-5-minimal",
-        "gpt-5-medium",
+        "gpt-5.4",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2",
+        "gpt-5.1-codex-mini",
     ]
 
     task = "Explain the difference between Python's list and tuple data structures. Provide examples and use cases."
@@ -237,29 +241,24 @@ async def demonstrate_model_selection_guidelines():
     guidelines = """
 CHOOSING THE RIGHT MODEL:
 
-GPT-5-CODEX MODELS (Specialized for coding):
-- gpt-5-codex-low:    Fast coding tasks, simple scripts, quick fixes
-- gpt-5-codex-medium: Balanced coding tasks, moderate complexity
-- gpt-5-codex-high:   Complex coding tasks, architecture decisions, debugging
-
-GPT-5 MODELS (General purpose):
-- gpt-5-minimal:      Fast responses, simple tasks, basic Q&A
-- gpt-5-low:          Quick explanations, straightforward queries
-- gpt-5-medium:       General tasks, balanced reasoning
-- gpt-5-high:         Complex problems, deep reasoning, analysis
+CURRENT FRONTIER / CODEX MODEL FAMILIES:
+- gpt-5.4:               Latest frontier agentic coding model
+- gpt-5.3-codex:         Frontier Codex-optimized coding model
+- gpt-5.3-codex-spark:   Ultra-fast coding model
+- gpt-5.2 / gpt-5.2-codex: Balanced alternatives
+- gpt-5.1-codex-mini:    Cheaper codex model
 
 PERFORMANCE CHARACTERISTICS:
-- Speed: minimal > low > medium > high
-- Reasoning: minimal < low < medium < high
-- Cost: minimal < low < medium < high (typically)
+- Most current frontier coding models expose: low, medium, high, xhigh
+- gpt-5.1-codex-mini exposes: medium, high
+- Speed generally decreases as reasoning depth increases
+- Cost generally increases as reasoning depth increases
 
 USE CASE RECOMMENDATIONS:
-- Quick coding fixes: gpt-5-codex-low
-- Code reviews: gpt-5-codex-medium
-- System architecture: gpt-5-codex-high
-- Simple questions: gpt-5-minimal
-- General tasks: gpt-5-medium
-- Complex analysis: gpt-5-high
+- Default coding example: gpt-5.4 with medium reasoning
+- Fast feedback loops: gpt-5.3-codex-spark
+- Deep architecture/debugging: gpt-5.4 or gpt-5.3-codex with xhigh
+- Lower-cost codex usage: gpt-5.1-codex-mini
 
 OPENAI-COMPATIBLE ENDPOINTS:
 - Use for custom models (Claude, Llama, etc.)
@@ -289,8 +288,8 @@ async def main():
             """
 Key Takeaways:
 - Choose models based on task complexity and speed requirements
-- Codex models are optimized for coding tasks
-- GPT-5 models are general purpose with different reasoning levels
+- Prefer gpt-5.4 in examples when you want the current frontier coding model
+- Reasoning presets depend on the selected model
 - OpenAI-compatible endpoints allow using custom models
 - Configure endpoints in ~/.codex/config.toml
 - Test different models to find the best fit for your use case


### PR DESCRIPTION
Refresh the README and shipped examples so they match the current Codex runtime and model lineup.

This updates the public examples to prefer `gpt-5.4` as the current frontier coding model, replaces lingering `gpt-5-codex-high` references in the app-server examples, and rewrites the model-configuration example so it reflects the current Codex menu and reasoning-level guidance instead of the old GPT-5 / gpt-5-codex naming scheme.

The architecture section was also corrected to show the modern split between the `codex exec` thread runtime and the app-server-backed `CodexModel` runtime. The previous PydanticAI model-provider diagram still described the legacy `codex exec --output-schema` path, which no longer matches how the integration works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced app-server JSON-RPC pathway documentation
  * Updated architecture diagrams and workflow sequences
  * Improved model configuration guidance including reasoning effort settings

* **Updates**
  * All code examples updated to use model version gpt-5.4
  * ThreadOptions API refined: model and model_reasoning_effort parameters are now separate

<!-- end of auto-generated comment: release notes by coderabbit.ai -->