### PR TITLE
Prepare 0.115.1 security fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG_SDK.md
+++ b/CHANGELOG_SDK.md
@@ -2,6 +2,16 @@
 
 This file tracks SDK-level changes. Keep the newest changes at the top.
 
+## [0.115.1] - Unreleased
+
+### Updated
+- Refreshed the locked optional `pydantic-ai` dependency graph to upgrade the
+  transitive `PyJWT` dependency to `2.12.1`, addressing the open GitHub
+  security advisory on `uv.lock` without changing the SDK API surface.
+- Added explicit least-privilege `GITHUB_TOKEN` permissions to the CI workflow
+  so the open CodeQL workflow-permissions alerts no longer rely on repository
+  defaults.
+
 ## [0.115.0] - 2026-03-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ typed results for each.
       <td><strong>Lifecycle</strong></td>
       <td>
         <a href="#ci-cd"><img src="https://img.shields.io/badge/CI%2FCD-Active-16a34a?style=flat&logo=githubactions&logoColor=white" alt="CI/CD badge" /></a>
-        <img src="https://img.shields.io/badge/Release-0.115.0-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release badge" />
+        <img src="https://img.shields.io/badge/Release-0.115.1-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release badge" />
         <a href="#license"><img src="https://img.shields.io/badge/License-Apache--2.0-0f766e?style=flat&logo=apache&logoColor=white" alt="License badge" /></a>
       </td>
     </tr>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "codex-sdk-python"
-version = "0.115.0"
+version = "0.115.1"
 description = "Python SDK for the Codex CLI agent with async threads, streaming events, and structured outputs"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/codex_sdk/__init__.py
+++ b/src/codex_sdk/__init__.py
@@ -83,7 +83,7 @@ from .thread import (
     Turn,
 )
 
-__version__ = "0.115.0"
+__version__ = "0.115.1"
 
 __all__ = [
     "AbortController",

--- a/uv.lock
+++ b/uv.lock
@@ -769,7 +769,7 @@ wheels = [
 
 [[package]]
 name = "codex-sdk-python"
-version = "0.115.0"
+version = "0.115.1"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -3683,11 +3683,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+dependencies = [
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- upgrade the locked PyJWT dependency to 2.12.1 for the optional pydantic-ai stack
- add explicit read-only GITHUB_TOKEN permissions to CI to address the open CodeQL workflow alerts
- bump the SDK version and changelog/readme metadata for the 0.115.1 patch line

## Validation
- uv sync --locked --all-extras --dev
- uv run black --check src tests examples scripts/install_git_hooks.py scripts/run_ci_checks.py scripts/setup_binary.py
- uv run isort --check-only src tests examples scripts/install_git_hooks.py scripts/run_ci_checks.py scripts/setup_binary.py
- uv run flake8 src tests scripts/install_git_hooks.py scripts/run_ci_checks.py scripts/setup_binary.py
- uv run mypy src
- uv run pytest --cov=codex_sdk --cov-report=term-missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * SDK version bumped to 0.115.1 with no breaking changes or API modifications
  * PyJWT transitive dependency updated to version 2.12.1 to ensure latest security fixes
  * GitHub Actions CI workflow configuration enhanced with explicit least-privilege GITHUB_TOKEN permissions, improving security posture and following industry best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->