### PR TITLE
Align SDK to Codex 0.117.0

### DIFF
--- a/CHANGELOG_SDK.md
+++ b/CHANGELOG_SDK.md
@@ -2,6 +2,39 @@
 
 This file tracks SDK-level changes. Keep the newest changes at the top.
 
+## [0.117.0] - 2026-03-28
+
+### Added
+- App-server helpers for newly exposed upstream RPCs:
+  `thread_shell_command`, `thread_background_terminals_clean`,
+  `experimental_feature_enablement_set`, `fs_watch`, and `fs_unwatch`.
+- `CodexModel(..., hooks=ThreadHooks(...))` now dispatches typed SDK thread hooks for
+  app-server-backed PydanticAI requests, including thread start, turn start/completion,
+  turn failure, and item lifecycle events.
+
+### Updated
+- `AppServerOptions` now supports `opt_out_notification_methods`, wiring
+  `initialize.capabilities.optOutNotificationMethods` for app-server clients that
+  want to suppress selected notification streams.
+- The PydanticAI model-provider path now runs through upstream
+  `Model.prepare_request()`, keeping request customization, output-mode handling,
+  builtin-tool validation, and thinking resolution aligned with PydanticAI `1.73.0`.
+- `CodexModel` now maps PydanticAI `model_settings["thinking"]` onto Codex
+  `model_reasoning_effort` when no explicit thread-level reasoning effort is set.
+- PydanticAI dependency support updated to `>=1.73.0,<2`, with the dev dependency
+  pinned to `1.73.0` for reproducible test coverage against the latest release.
+- `thread_list` now supports the upstream `cwd` and `search_term` filters.
+- `plugin_list` now supports `force_remote_sync`, `config_batch_write` now supports
+  `reload_user_config`, and `windows_sandbox_setup_start` now accepts an optional
+  workspace `cwd`.
+- README and PydanticAI examples updated to show typed output models, runtime hooks,
+  and per-run thinking configuration.
+
+### Notes
+- Codex 0.116.0 and 0.117.0 introduced app-server support for thread-scoped `!`
+  shell commands, filesystem watch subscriptions, richer plugin sync flows, and
+  per-connection notification suppression.
+
 ## [0.115.1] - 2026-03-17
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ typed results for each.
       <td><strong>Lifecycle</strong></td>
       <td>
         <a href="#ci-cd"><img src="https://img.shields.io/badge/CI%2FCD-Active-16a34a?style=flat&logo=githubactions&logoColor=white" alt="CI/CD badge" /></a>
-        <img src="https://img.shields.io/badge/Release-0.115.1-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release badge" />
+        <img src="https://img.shields.io/badge/Release-0.117.0-6b7280?style=flat&logo=pypi&logoColor=white" alt="Release badge" />
         <a href="#license"><img src="https://img.shields.io/badge/License-Apache--2.0-0f766e?style=flat&logo=apache&logoColor=white" alt="License badge" /></a>
       </td>
     </tr>
@@ -323,16 +323,19 @@ The SDK also exposes helpers for most app-server endpoints:
 
 - Threads: `thread_start`, `thread_resume`, `thread_fork`, `thread_list`, `thread_loaded_list`,
   `thread_read`, `thread_archive`, `thread_unsubscribe`, `thread_unarchive`,
-  `thread_name_set`, `thread_compact_start`, `thread_rollback`, `thread_metadata_update`
+  `thread_name_set`, `thread_compact_start`, `thread_shell_command`,
+  `thread_background_terminals_clean`, `thread_rollback`, `thread_metadata_update`
 - Config: `config_read`, `config_value_write`, `config_batch_write`, `config_requirements_read`
 - Skills: `skills_list`, `skills_remote_list`, `skills_remote_export`, `skills_remote_read` (alias),
   `skills_remote_write` (alias), `skills_config_write`
 - Turns/review: `turn_start`, `turn_steer`, `turn_interrupt`, `review_start`, `turn_session`
-- Models: `model_list`, `experimental_feature_list`
+- Models/features: `model_list`, `experimental_feature_list`,
+  `experimental_feature_enablement_set`
 - Collaboration modes: `collaboration_mode_list` (experimental)
 - Plugins: `plugin_list`, `plugin_read`, `plugin_install`, `plugin_uninstall`
 - Filesystem (experimental): `fs_copy`, `fs_create_directory`, `fs_get_metadata`,
-  `fs_read_directory`, `fs_read_file`, `fs_remove`, `fs_write_file`
+  `fs_read_directory`, `fs_read_file`, `fs_remove`, `fs_write_file`, `fs_watch`,
+  `fs_unwatch`
 - One-off commands: `command_exec`, `command_exec_write`, `command_exec_resize`,
   `command_exec_terminate`
 - MCP auth/status: `mcp_server_oauth_login`, `mcp_server_refresh`, `mcp_server_status_list`
@@ -346,13 +349,18 @@ These map 1:1 to the Codex app-server protocol; see `codex/codex-rs/app-server/R
 for payload shapes and event semantics.
 
 Note: some endpoints and fields are gated behind an experimental capability; set
-`AppServerOptions(experimental_api_enabled=True)` to opt in.
+`AppServerOptions(experimental_api_enabled=True)` to opt in. You can also suppress
+noisy notification families per connection with
+`AppServerOptions(opt_out_notification_methods=[...])`.
 
 `ApprovalDecisions` also supports `permissions_request` for auto-responding to
 `item/permissions/requestApproval` server requests during `turn_session()`.
 
-`thread_list` supports `archived`, `sort_key`, and `source_kinds` filters, and `config_read` accepts an optional `cwd`
-to compute the effective layered config for a specific working directory.
+`thread_list` supports `archived`, `sort_key`, `source_kinds`, `cwd`, and `search_term`
+filters, and `config_read` accepts an optional `cwd` to compute the effective layered
+config for a specific working directory. `plugin_list` accepts `force_remote_sync`,
+`config_batch_write` accepts `reload_user_config`, and `windows_sandbox_setup_start`
+accepts an optional workspace `cwd`.
 
 Codex 0.115.0 also adds experimental granular approval routing (`approval_policy="granular"`)
 and guardian reviewer selection via `approvals_reviewer`; the app-server helpers pass those
@@ -613,7 +621,7 @@ Example scripts under `examples/`:
 - `app_server_turn_session.py`: approval-handled turns over app-server.
 - `hooks_streaming.py`: event hooks for streaming runs.
 - `notify_hook.py`: notify script for CLI callbacks.
-- `pydantic_ai_model_provider.py`: Codex as a PydanticAI model provider.
+- `pydantic_ai_model_provider.py`: Codex as a PydanticAI model provider with typed output and SDK hooks.
 - `pydantic_ai_model_provider_streaming.py`: live PydanticAI text streaming over `CodexModel`.
 - `pydantic_ai_handoff.py`: Codex as a PydanticAI tool.
 
@@ -644,10 +652,16 @@ This SDK offers two ways to integrate with PydanticAI:
 Use `CodexModel` to delegate tool-call planning and text generation to Codex, while PydanticAI executes tools and validates outputs.
 
 ```python
+from pydantic import BaseModel
 from pydantic_ai import Agent, Tool
 
+from codex_sdk import ThreadHooks
 from codex_sdk.integrations.pydantic_ai_model import CodexModel
 from codex_sdk.options import ThreadOptions
+
+class MathAnswer(BaseModel):
+    result: int
+    explanation: str
 
 def add(a: int, b: int) -> int:
     return a + b
@@ -657,12 +671,19 @@ model = CodexModel(
         model="gpt-5.4",
         sandbox_mode="read-only",
         skip_git_repo_check=True,
-    )
+    ),
+    hooks=ThreadHooks(
+        on_turn_started=lambda _event: print("[codex] turn started"),
+        on_turn_completed=lambda event: print(event.usage.output_tokens),
+    ),
 )
-agent = Agent(model, tools=[Tool(add)])
+agent = Agent(model, tools=[Tool(add)], output_type=MathAnswer)
 
-result = agent.run_sync("What's 19 + 23? Use the add tool.")
-print(result.output)
+result = agent.run_sync(
+    "What's 19 + 23? Use the add tool and return a structured answer.",
+    model_settings={"thinking": "low"},
+)
+print(result.output.model_dump_json(indent=2))
 ```
 
 For live text streaming in a terminal or web UI:
@@ -683,12 +704,22 @@ How it works:
 - `CodexModel` builds a JSON schema envelope with `tool_calls` and `final`.
 - Codex emits tool calls as JSON strings; PydanticAI runs them.
 - If `allow_text_output` is true, Codex can place final text in `final`.
-- This SDK targets the current PydanticAI release line (`>=1.68.0,<2`).
+- This SDK targets the current PydanticAI release line (`>=1.73.0,<2`) and the
+  dev environment is pinned to `pydantic-ai==1.73.0`.
 - `Agent.run_stream()`, `Agent.run_stream_events()`, and `Agent.run_stream_sync()`
   work with `CodexModel`.
+- `CodexModel(..., hooks=ThreadHooks(...))` reuses the SDK's typed thread-hook surface
+  for app-server-backed PydanticAI runs.
+- `model_settings={"thinking": ...}` is translated into Codex `model_reasoning_effort`
+  when you have not already set an explicit `ThreadOptions.model_reasoning_effort`.
+- `CodexModel` now runs through PydanticAI's base `Model.prepare_request()` flow, so
+  upstream request customization, output-mode normalization, and builtin-tool validation
+  stay aligned with the latest PydanticAI release.
 - Text deltas are forwarded live from agent-message updates when Codex emits them, including
   envelope-backed `final` text. Tool calls are forwarded as soon as Codex produces a valid
   envelope update, and `streamed.get()` is reconciled to the canonical final turn result.
+- Provider-native builtin tools and image output are intentionally rejected unless the
+  upstream PydanticAI base model marks them as supported for this backend.
 
 Safety defaults (you can override with your own `ThreadOptions`):
 - `sandbox_mode="read-only"`

--- a/examples/pydantic_ai_model_provider.py
+++ b/examples/pydantic_ai_model_provider.py
@@ -6,14 +6,22 @@ plans and final responses through the app-server-backed CodexModel runtime.
 
 Requires:
   uv add "codex-sdk-python[pydantic-ai]"
+  codex login   (or set CODEX_API_KEY)
 """
 
 from __future__ import annotations
 
+from pydantic import BaseModel
 from pydantic_ai import Agent, Tool
 
+from codex_sdk import ThreadHooks
 from codex_sdk.integrations.pydantic_ai_model import CodexModel
 from codex_sdk.options import ThreadOptions
+
+
+class MathAnswer(BaseModel):
+    result: int
+    explanation: str
 
 
 def add(a: int, b: int) -> int:
@@ -27,16 +35,26 @@ def main() -> None:
             model="gpt-5.4",
             sandbox_mode="read-only",
             skip_git_repo_check=True,
-        )
+        ),
+        hooks=ThreadHooks(
+            on_turn_started=lambda _event: print("[codex] turn started"),
+            on_turn_completed=lambda event: print(
+                f"[codex] output tokens: {event.usage.output_tokens}"
+            ),
+        ),
     )
 
     agent = Agent(
         model,
         tools=[Tool(add)],
+        output_type=MathAnswer,
     )
 
-    result = agent.run_sync("What's 19 + 23? Use the add tool.")
-    print(result.output)
+    result = agent.run_sync(
+        "What's 19 + 23? Use the add tool and return a structured answer.",
+        model_settings={"thinking": "low"},
+    )
+    print(result.output.model_dump_json(indent=2))
 
 
 if __name__ == "__main__":

--- a/examples/pydantic_ai_model_provider_streaming.py
+++ b/examples/pydantic_ai_model_provider_streaming.py
@@ -18,6 +18,7 @@ import asyncio
 
 from pydantic_ai import Agent
 
+from codex_sdk import ThreadHooks
 from codex_sdk.integrations.pydantic_ai_model import CodexModel
 from codex_sdk.options import ThreadOptions
 
@@ -28,7 +29,13 @@ async def main() -> None:
             model="gpt-5.4",
             sandbox_mode="read-only",
             skip_git_repo_check=True,
-        )
+        ),
+        hooks=ThreadHooks(
+            on_turn_started=lambda _event: print("[codex] streaming turn started"),
+            on_turn_completed=lambda event: print(
+                f"\n[codex] output tokens: {event.usage.output_tokens}"
+            ),
+        ),
     )
 
     agent = Agent(model, output_type=str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "codex-sdk-python"
-version = "0.115.1"
+version = "0.117.0"
 description = "Python SDK for the Codex CLI agent with async threads, streaming events, and structured outputs"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -37,7 +37,7 @@ pydantic = [
     "pydantic>=2",
 ]
 pydantic-ai = [
-    "pydantic-ai>=1.68.0,<2; python_version >= '3.10'",
+    "pydantic-ai>=1.73.0,<2; python_version >= '3.10'",
 ]
 logfire = [
     # `pydantic-ai` imports the `logfire` module, which is provided by the
@@ -52,7 +52,7 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0",
     "pydantic>=2",
-    "pydantic-ai>=1.68.0,<2; python_version >= '3.10'",
+    "pydantic-ai==1.73.0; python_version >= '3.10'",
     "black>=22.0",
     "isort>=5.0",
     "mypy>=1.0",

--- a/src/codex_sdk/__init__.py
+++ b/src/codex_sdk/__init__.py
@@ -83,7 +83,7 @@ from .thread import (
     Turn,
 )
 
-__version__ = "0.115.1"
+__version__ = "0.117.0"
 
 __all__ = [
     "AbortController",

--- a/src/codex_sdk/app_server.py
+++ b/src/codex_sdk/app_server.py
@@ -432,6 +432,15 @@ class AppServerClient:
         if self._options.experimental_api_enabled:
             capabilities["experimentalApi"] = True
         if self._options.opt_out_notification_methods:
+            reserved_methods = {"turn/completed", "turn/failed"}
+            reserved_opt_outs = sorted(
+                reserved_methods & set(self._options.opt_out_notification_methods)
+            )
+            if reserved_opt_outs:
+                raise CodexError(
+                    "opt_out_notification_methods cannot suppress required turn "
+                    f"lifecycle notifications: {reserved_opt_outs}"
+                )
             capabilities["optOutNotificationMethods"] = list(
                 self._options.opt_out_notification_methods
             )

--- a/src/codex_sdk/app_server.py
+++ b/src/codex_sdk/app_server.py
@@ -54,6 +54,8 @@ class AppServerOptions:
     client_info: Optional[AppServerClientInfo] = None
     # Enables experimental app-server methods/fields gated behind initialize.capabilities.
     experimental_api_enabled: bool = False
+    # Exact notification method names to suppress for this connection.
+    opt_out_notification_methods: Optional[Sequence[str]] = None
     auto_initialize: bool = True
     request_timeout: Optional[float] = None
 
@@ -426,8 +428,15 @@ class AppServerClient:
             client_info = self._default_client_info()
 
         params: Dict[str, Any] = {"clientInfo": client_info.as_dict()}
+        capabilities: Dict[str, Any] = {}
         if self._options.experimental_api_enabled:
-            params["capabilities"] = {"experimentalApi": True}
+            capabilities["experimentalApi"] = True
+        if self._options.opt_out_notification_methods:
+            capabilities["optOutNotificationMethods"] = list(
+                self._options.opt_out_notification_methods
+            )
+        if capabilities:
+            params["capabilities"] = capabilities
 
         result = await self._request_dict("initialize", params)
         await self.notify("initialized")
@@ -567,6 +576,8 @@ class AppServerClient:
         model_providers: Optional[Sequence[str]] = None,
         source_kinds: Optional[Sequence[str]] = None,
         archived: Optional[bool] = None,
+        cwd: Optional[Union[str, Path]] = None,
+        search_term: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Retrieve a page of threads from the app-server with optional filtering and sorting.
@@ -579,6 +590,8 @@ class AppServerClient:
             source_kinds: Filter threads by one or more source kinds.
             archived: If set, restrict results to archived (`True`) or unarchived (`False`)
                 threads.
+            cwd: Optional working directory filter.
+            search_term: Optional free-text search term.
 
         Returns:
             The raw response dictionary returned by the app-server for the `thread/list`
@@ -597,6 +610,10 @@ class AppServerClient:
             params["source_kinds"] = list(source_kinds)
         if archived is not None:
             params["archived"] = archived
+        if cwd is not None:
+            params["cwd"] = str(cwd)
+        if search_term is not None:
+            params["search_term"] = search_term
         return await self._request_dict("thread/list", _coerce_keys(params) or None)
 
     async def thread_read(
@@ -657,6 +674,21 @@ class AppServerClient:
             dict: The app-server's result payload for the compaction start request.
         """
         return await self._request_dict("thread/compact/start", {"threadId": thread_id})
+
+    async def thread_shell_command(
+        self, thread_id: str, *, command: str
+    ) -> Dict[str, Any]:
+        """Run a user-initiated `!` shell command against a thread."""
+        return await self._request_dict(
+            "thread/shellCommand",
+            {"threadId": thread_id, "command": command},
+        )
+
+    async def thread_background_terminals_clean(self, thread_id: str) -> Dict[str, Any]:
+        """Terminate all running background terminals for a thread."""
+        return await self._request_dict(
+            "thread/backgroundTerminals/clean", {"threadId": thread_id}
+        )
 
     async def thread_rollback(
         self, thread_id: str, *, num_turns: int
@@ -747,12 +779,14 @@ class AppServerClient:
         edits: Sequence[Mapping[str, Any]],
         file_path: Optional[str] = None,
         expected_version: Optional[str] = None,
+        reload_user_config: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Apply multiple configuration edits in a single app-server request."""
         params = {
             "edits": list(edits),
             "file_path": file_path,
             "expected_version": expected_version,
+            "reload_user_config": reload_user_config,
         }
         return await self._request_dict("config/batchWrite", _coerce_keys(params))
 
@@ -1039,18 +1073,32 @@ class AppServerClient:
             params["limit"] = limit
         return await self._request_dict("experimentalFeature/list", params or None)
 
+    async def experimental_feature_enablement_set(
+        self, *, feature_enablement: Mapping[str, bool]
+    ) -> Dict[str, Any]:
+        """Patch in-memory app-server feature enablement for supported feature keys."""
+        return await self._request_dict(
+            "experimentalFeature/enablement/set",
+            {"featureEnablement": dict(feature_enablement)},
+        )
+
     async def collaboration_mode_list(self) -> Dict[str, Any]:
         """List supported collaboration modes from the app-server."""
         return await self._request_dict("collaborationMode/list", {})
 
     async def plugin_list(
-        self, *, cwds: Optional[Sequence[Union[str, Path]]] = None
+        self,
+        *,
+        cwds: Optional[Sequence[Union[str, Path]]] = None,
+        force_remote_sync: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """List available plugin marketplaces and plugins."""
         params: Dict[str, Any] = {}
         if cwds is not None:
             params["cwds"] = [str(path) for path in cwds]
-        return await self._request_dict("plugin/list", params or None)
+        if force_remote_sync is not None:
+            params["force_remote_sync"] = force_remote_sync
+        return await self._request_dict("plugin/list", _coerce_keys(params) or None)
 
     async def plugin_install(
         self,
@@ -1146,6 +1194,14 @@ class AppServerClient:
         """Write a file via the experimental filesystem API."""
         params = {"path": str(path), "data_base64": data_base64}
         return await self._request_dict("fs/writeFile", _coerce_keys(params))
+
+    async def fs_watch(self, *, path: Union[str, Path]) -> Dict[str, Any]:
+        """Subscribe to filesystem change notifications for a path."""
+        return await self._request_dict("fs/watch", {"path": str(path)})
+
+    async def fs_unwatch(self, *, watch_id: str) -> Dict[str, Any]:
+        """Cancel a previous filesystem watch subscription."""
+        return await self._request_dict("fs/unwatch", {"watchId": watch_id})
 
     async def command_exec(
         self,
@@ -1274,9 +1330,17 @@ class AppServerClient:
             "externalAgentConfig/import", _coerce_keys(params)
         )
 
-    async def windows_sandbox_setup_start(self, *, mode: str) -> Dict[str, Any]:
+    async def windows_sandbox_setup_start(
+        self,
+        *,
+        mode: str,
+        cwd: Optional[Union[str, Path]] = None,
+    ) -> Dict[str, Any]:
         """Start Windows sandbox setup in the selected mode."""
-        return await self._request_dict("windowsSandbox/setupStart", {"mode": mode})
+        params: Dict[str, Any] = {"mode": mode}
+        if cwd is not None:
+            params["cwd"] = str(cwd)
+        return await self._request_dict("windowsSandbox/setupStart", params)
 
     async def account_login_start(self, *, params: Mapping[str, Any]) -> Dict[str, Any]:
         """Start an account login flow via the app-server."""

--- a/src/codex_sdk/integrations/pydantic_ai_model.py
+++ b/src/codex_sdk/integrations/pydantic_ai_model.py
@@ -20,11 +20,37 @@ from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass, field, is_dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, AsyncIterator, Dict, Iterator, List, Mapping, Optional, Sequence
+from typing import (
+    Any,
+    AsyncIterator,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    cast,
+)
 
 from ..app_server import AppServerClient, AppServerNotification, AppServerOptions
+from ..events import (
+    ItemCompletedEvent,
+    ItemStartedEvent,
+    ItemUpdatedEvent,
+    ThreadError,
+    ThreadErrorEvent,
+    ThreadStartedEvent,
+    TurnCompletedEvent,
+    TurnFailedEvent,
+    TurnStartedEvent,
+    Usage,
+)
 from ..exceptions import CodexError, TurnFailedError
-from ..options import CodexOptions, ThreadOptions
+from ..hooks import ThreadHooks, dispatch_event
+from ..items import (
+    ThreadItem,
+)
+from ..options import CodexOptions, ModelReasoningEffort, ThreadOptions
 from ..telemetry import span
 
 try:
@@ -91,6 +117,15 @@ class _TurnAccumulationState:
     next_vendor_part_id: int = 0
     usage: Optional[RequestUsage] = None
     turn_failed_message: Optional[str] = None
+
+
+@dataclass
+class _HookDispatchState:
+    """Tracks which synthetic thread events were already dispatched for one turn."""
+
+    turn_started: bool = False
+    turn_completed: bool = False
+    turn_failed: bool = False
 
 
 def _jsonable(value: Any) -> Any:
@@ -522,6 +557,63 @@ def _extract_turn_failure_message(notification: AppServerNotification) -> Option
     return "Turn failed"
 
 
+def _request_usage_to_thread_usage(usage: RequestUsage) -> Usage:
+    """Convert PydanticAI usage into the SDK's thread-usage shape."""
+    return Usage(
+        input_tokens=getattr(usage, "input_tokens", 0),
+        cached_input_tokens=getattr(usage, "cache_read_tokens", 0),
+        output_tokens=getattr(usage, "output_tokens", 0),
+    )
+
+
+def _thread_reasoning_effort_from_thinking(
+    thinking: Any,
+) -> Optional[ModelReasoningEffort]:
+    """Map PydanticAI's unified thinking setting onto Codex reasoning effort."""
+    if thinking is True:
+        return None
+    if thinking is False:
+        return "none"
+    if thinking in {"minimal", "low", "medium", "high", "xhigh"}:
+        return cast(ModelReasoningEffort, thinking)
+    return None
+
+
+def _normalize_notification_item_type(item_type: Any) -> Any:
+    """Normalize best-effort item type aliases from app-server payloads."""
+    if not isinstance(item_type, str):
+        return item_type
+    if "_" in item_type:
+        return item_type
+
+    normalized: List[str] = []
+    for index, char in enumerate(item_type):
+        if char.isupper() and index > 0:
+            normalized.append("_")
+        normalized.append(char.lower())
+    return "".join(normalized)
+
+
+def _notification_item_to_thread_item(item: Mapping[str, Any]) -> Optional[ThreadItem]:
+    """Convert an app-server item payload into a typed SDK ThreadItem."""
+    from ..thread import Thread
+
+    normalized_item = dict(item)
+    normalized_item["type"] = _normalize_notification_item_type(item.get("type"))
+
+    if (
+        normalized_item.get("type") == "agent_message"
+        and "text" not in normalized_item
+        and isinstance(normalized_item.get("content"), str)
+    ):
+        normalized_item["text"] = normalized_item["content"]
+
+    try:
+        return Thread._parse_item(cast(Any, None), normalized_item)
+    except Exception:
+        return None
+
+
 class CodexStreamedResponse(StreamedResponse):
     """Incremental streamed response wrapper for app-server-backed CodexModel."""
 
@@ -738,6 +830,7 @@ class CodexModel(Model):
         system: str = "openai",
         performance_profile: str = "balanced",
         thread_reuse_mode: str = "run",
+        hooks: Optional[ThreadHooks] = None,
     ) -> None:
         """Create an app-server-backed Codex model provider.
 
@@ -759,12 +852,13 @@ class CodexModel(Model):
         self._thread_options = self._prepare_thread_options(thread_options)
 
         if profile is None:
-            profile = ModelProfile(supports_tools=True)
+            profile = ModelProfile(supports_tools=True, supports_thinking=True)
         super().__init__(settings=settings, profile=profile)
 
         self._system = system
         self._request_lock = asyncio.Lock()
         self._closed = False
+        self._hooks = hooks
 
         self._app_client = app_server
         self._owns_app_client = app_server is None
@@ -776,6 +870,7 @@ class CodexModel(Model):
         )
 
         self._thread_id: Optional[str] = None
+        self._active_thread_reasoning_effort: Optional[ModelReasoningEffort] = None
         self._messages_seen = 0
 
     @property
@@ -794,7 +889,40 @@ class CodexModel(Model):
         model_request_parameters: ModelRequestParameters,
     ) -> tuple[Optional[ModelSettings], ModelRequestParameters]:
         """Hook to customize request settings/parameters before execution."""
-        return model_settings, model_request_parameters
+        prepared = super().prepare_request(model_settings, model_request_parameters)
+        return cast(
+            tuple[Optional[ModelSettings], ModelRequestParameters],
+            prepared,
+        )
+
+    def resolve_hooks(
+        self,
+        model_settings: Optional[ModelSettings],
+        model_request_parameters: ModelRequestParameters,
+    ) -> Optional[ThreadHooks]:
+        """Resolve typed SDK thread hooks for the current PydanticAI request."""
+        del model_settings, model_request_parameters
+        return self._hooks
+
+    def _prepare_request_context(
+        self,
+        model_settings: Optional[ModelSettings],
+        model_request_parameters: ModelRequestParameters,
+    ) -> tuple[
+        Optional[ModelSettings],
+        ModelRequestParameters,
+        Optional[ThreadHooks],
+        ThreadOptions,
+    ]:
+        """Resolve prepared request inputs shared by request and request_stream."""
+        model_settings, model_request_parameters = self.prepare_request(
+            model_settings, model_request_parameters
+        )
+        hooks = self.resolve_hooks(model_settings, model_request_parameters)
+        resolved_thread_options = self._resolved_thread_options(
+            model_request_parameters
+        )
+        return model_settings, model_request_parameters, hooks, resolved_thread_options
 
     async def close(self) -> None:
         """Close owned app-server resources and reset cached thread state."""
@@ -806,6 +934,7 @@ class CodexModel(Model):
             finally:
                 self._app_client = None
                 self._thread_id = None
+                self._active_thread_reasoning_effort = None
                 self._messages_seen = 0
 
     async def _ensure_client(self) -> AppServerClient:
@@ -874,10 +1003,30 @@ class CodexModel(Model):
             config_overrides=codex_options.config_overrides,
         )
 
-    def _thread_start_params(self) -> Dict[str, Any]:
+    def _resolved_thread_options(
+        self, model_request_parameters: ModelRequestParameters
+    ) -> ThreadOptions:
+        """Resolve per-request thread options without mutating model defaults."""
+        if self._thread_options.model_reasoning_effort is not None:
+            return self._thread_options
+
+        reasoning_effort = _thread_reasoning_effort_from_thinking(
+            model_request_parameters.thinking
+        )
+        if reasoning_effort is None:
+            return self._thread_options
+
+        return replace(
+            self._thread_options,
+            model_reasoning_effort=reasoning_effort,
+        )
+
+    def _thread_start_params(
+        self, thread_options: Optional[ThreadOptions] = None
+    ) -> Dict[str, Any]:
         """Build app-server `thread/start` params from current thread options."""
         params: Dict[str, Any] = {}
-        options = self._thread_options
+        options = thread_options or self._thread_options
 
         if options.model is not None:
             params["model"] = options.model
@@ -940,28 +1089,46 @@ class CodexModel(Model):
 
         return params
 
-    async def _ensure_thread(self, messages: Sequence[ModelMessage]) -> str:
+    async def _ensure_thread(
+        self,
+        messages: Sequence[ModelMessage],
+        hooks: Optional[ThreadHooks] = None,
+        thread_options: Optional[ThreadOptions] = None,
+    ) -> str:
         """Ensure a reusable Codex thread exists for the current message stream."""
+        resolved_thread_options = thread_options or self._thread_options
+        requested_reasoning_effort = resolved_thread_options.model_reasoning_effort
         history_len = len(messages)
         if self._thread_id is not None:
             should_reset = history_len < self._messages_seen
             if self._thread_reuse_mode == "run" and history_len <= self._messages_seen:
                 should_reset = True
+            if requested_reasoning_effort != self._active_thread_reasoning_effort:
+                should_reset = True
             if should_reset:
                 self._thread_id = None
+                self._active_thread_reasoning_effort = None
                 self._messages_seen = 0
 
         if self._thread_id:
             return self._thread_id
 
         client = await self._ensure_client()
-        response = await client.thread_start(**self._thread_start_params())
+        response = await client.thread_start(
+            **self._thread_start_params(resolved_thread_options)
+        )
         thread = response.get("thread") if isinstance(response, dict) else None
         thread_id = thread.get("id") if isinstance(thread, Mapping) else None
         if not isinstance(thread_id, str) or not thread_id:
             raise CodexError("thread/start response missing thread id")
         self._thread_id = thread_id
+        self._active_thread_reasoning_effort = requested_reasoning_effort
         self._messages_seen = 0
+        if hooks is not None:
+            await dispatch_event(
+                hooks,
+                ThreadStartedEvent(type="thread.started", thread_id=thread_id),
+            )
         return thread_id
 
     def _slice_incremental_messages(
@@ -1014,6 +1181,14 @@ class CodexModel(Model):
                 "- Text output is NOT allowed; to finish, call exactly one output tool and keep final empty."
             )
 
+        prompted_output_instructions = (
+            model_request_parameters.prompted_output_instructions
+        )
+        if prompted_output_instructions:
+            prompt_sections.extend(
+                ["", "Structured output instructions:", prompted_output_instructions]
+            )
+
         if tool_manifest:
             prompt_sections.extend(["", tool_manifest])
 
@@ -1022,6 +1197,62 @@ class CodexModel(Model):
             prompt_sections.extend(["", "Conversation so far:", history])
 
         return "\n".join(prompt_sections).strip()
+
+    async def _dispatch_notification_hooks(
+        self,
+        *,
+        notification: AppServerNotification,
+        hooks: Optional[ThreadHooks],
+        hook_state: _HookDispatchState,
+    ) -> None:
+        """Map app-server notifications onto typed SDK thread hooks."""
+        if hooks is None:
+            return
+
+        if notification.method == "turn/failed":
+            if hook_state.turn_failed:
+                return
+            message = _extract_turn_failure_message(notification) or "Turn failed"
+            hook_state.turn_failed = True
+            await dispatch_event(
+                hooks,
+                TurnFailedEvent(
+                    type="turn.failed",
+                    error=ThreadError(message=message),
+                ),
+            )
+            return
+
+        if notification.method == "error":
+            params = notification.params
+            message = "Unknown error"
+            if isinstance(params, Mapping):
+                raw_message = params.get("message")
+                if isinstance(raw_message, str) and raw_message:
+                    message = raw_message
+            await dispatch_event(hooks, ThreadErrorEvent(type="error", message=message))
+            return
+
+        event_type_map = {
+            "item/started": ItemStartedEvent,
+            "item/updated": ItemUpdatedEvent,
+            "item/completed": ItemCompletedEvent,
+        }
+        event_cls = event_type_map.get(notification.method)
+        if event_cls is None:
+            return
+
+        for raw_item in _notification_items(notification):
+            item = _notification_item_to_thread_item(raw_item)
+            if item is None:
+                continue
+            await dispatch_event(
+                hooks,
+                event_cls(
+                    type=notification.method.replace("/", "."),
+                    item=item,
+                ),
+            )
 
     def _handle_notification(
         self,
@@ -1116,11 +1347,13 @@ class CodexModel(Model):
         prompt: str,
         model_request_parameters: ModelRequestParameters,
         streamed: Optional[CodexStreamedResponse] = None,
+        hooks: Optional[ThreadHooks] = None,
     ) -> tuple[List[Any], RequestUsage]:
         """Execute one app-server turn and parse it into PydanticAI parts."""
         client = await self._ensure_client()
         session = await client.turn_session(thread_id, prompt)
         state = _TurnAccumulationState()
+        hook_state = _HookDispatchState()
 
         allow_stream_text = bool(
             streamed is not None and model_request_parameters.allow_text_output
@@ -1131,6 +1364,10 @@ class CodexModel(Model):
             and not model_request_parameters.output_tools
         )
 
+        if hooks is not None:
+            hook_state.turn_started = True
+            await dispatch_event(hooks, TurnStartedEvent(type="turn.started"))
+
         async for notification in session.notifications():
             self._handle_notification(
                 notification=notification,
@@ -1139,12 +1376,26 @@ class CodexModel(Model):
                 allow_stream_text=allow_stream_text,
                 stream_raw_text=stream_raw_text,
             )
+            await self._dispatch_notification_hooks(
+                notification=notification,
+                hooks=hooks,
+                hook_state=hook_state,
+            )
 
         final_turn = await session.wait()
         if state.turn_failed_message:
             raise TurnFailedError(state.turn_failed_message)
 
         usage = state.usage or _extract_usage_from_turn(final_turn) or RequestUsage()
+        if hooks is not None and not hook_state.turn_completed:
+            hook_state.turn_completed = True
+            await dispatch_event(
+                hooks,
+                TurnCompletedEvent(
+                    type="turn.completed",
+                    usage=_request_usage_to_thread_usage(usage),
+                ),
+            )
         final_text = _extract_turn_text(final_turn)
         if not final_text:
             final_text = state.latest_agent_text
@@ -1218,17 +1469,17 @@ class CodexModel(Model):
     async def _run_codex_request(
         self,
         messages: list[ModelMessage],
-        model_settings: Optional[ModelSettings],
         model_request_parameters: ModelRequestParameters,
+        hooks: Optional[ThreadHooks],
+        resolved_thread_options: ThreadOptions,
         streamed: Optional[CodexStreamedResponse] = None,
-    ) -> tuple[List[Any], RequestUsage, str, ModelRequestParameters]:
+    ) -> tuple[List[Any], RequestUsage, str]:
         """Run one model request via app-server transport."""
-        model_settings, model_request_parameters = self.prepare_request(
-            model_settings, model_request_parameters
+        thread_id = await self._ensure_thread(
+            messages,
+            hooks=hooks,
+            thread_options=resolved_thread_options,
         )
-        del model_settings
-
-        thread_id = await self._ensure_thread(messages)
         incremental_messages, seen_after = self._slice_incremental_messages(messages)
         prompt = self._build_prompt(
             messages=incremental_messages,
@@ -1237,8 +1488,8 @@ class CodexModel(Model):
 
         with span(
             "codex_sdk.pydantic_ai.model_request",
-            model=self._thread_options.model,
-            sandbox_mode=self._thread_options.sandbox_mode,
+            model=resolved_thread_options.model,
+            sandbox_mode=resolved_thread_options.sandbox_mode,
             transport="app_server",
             performance_profile=self._performance_profile,
         ):
@@ -1247,10 +1498,11 @@ class CodexModel(Model):
                 prompt=prompt,
                 model_request_parameters=model_request_parameters,
                 streamed=streamed,
+                hooks=hooks,
             )
 
         self._messages_seen = seen_after
-        return parts, usage, thread_id, model_request_parameters
+        return parts, usage, thread_id
 
     async def request(
         self,
@@ -1261,13 +1513,24 @@ class CodexModel(Model):
         """Run a request and return a completed model response."""
         async with self._request_lock:
             try:
-                parts, usage, thread_id, _ = await self._run_codex_request(
+                (
+                    _,
+                    model_request_parameters,
+                    hooks,
+                    resolved_thread_options,
+                ) = self._prepare_request_context(
+                    model_settings,
+                    model_request_parameters,
+                )
+                parts, usage, thread_id = await self._run_codex_request(
                     messages=messages,
-                    model_settings=model_settings,
                     model_request_parameters=model_request_parameters,
+                    hooks=hooks,
+                    resolved_thread_options=resolved_thread_options,
                 )
             except Exception:
                 self._thread_id = None
+                self._active_thread_reasoning_effort = None
                 self._messages_seen = 0
                 raise
 
@@ -1290,6 +1553,15 @@ class CodexModel(Model):
         """Run a request and stream incremental response events."""
         del run_context
         async with self._request_lock:
+            (
+                _,
+                model_request_parameters,
+                hooks,
+                resolved_thread_options,
+            ) = self._prepare_request_context(
+                model_settings,
+                model_request_parameters,
+            )
             streamed = CodexStreamedResponse(
                 model_request_parameters=model_request_parameters,
                 model_name=self.model_name,
@@ -1299,15 +1571,17 @@ class CodexModel(Model):
             async def _runner() -> None:
                 thread_id: Optional[str] = self._thread_id
                 try:
-                    parts, usage, thread_id, _ = await self._run_codex_request(
+                    parts, usage, thread_id = await self._run_codex_request(
                         messages=messages,
-                        model_settings=model_settings,
                         model_request_parameters=model_request_parameters,
+                        hooks=hooks,
+                        resolved_thread_options=resolved_thread_options,
                         streamed=streamed,
                     )
                     streamed.finish(usage=usage, thread_id=thread_id, parts=parts)
                 except Exception as exc:  # pragma: no cover - defensive
                     self._thread_id = None
+                    self._active_thread_reasoning_effort = None
                     self._messages_seen = 0
                     streamed.finish(thread_id=thread_id, error=exc)
 

--- a/src/codex_sdk/integrations/pydantic_ai_model.py
+++ b/src/codex_sdk/integrations/pydantic_ai_model.py
@@ -45,13 +45,14 @@ from ..events import (
     TurnStartedEvent,
     Usage,
 )
-from ..exceptions import CodexError, TurnFailedError
+from ..exceptions import CodexError, CodexParseError, TurnFailedError
 from ..hooks import ThreadHooks, dispatch_event
 from ..items import (
     ThreadItem,
 )
 from ..options import CodexOptions, ModelReasoningEffort, ThreadOptions
 from ..telemetry import span
+from ..thread import parse_thread_item_payload
 
 try:
     from pydantic_ai.messages import (
@@ -596,8 +597,6 @@ def _normalize_notification_item_type(item_type: Any) -> Any:
 
 def _notification_item_to_thread_item(item: Mapping[str, Any]) -> Optional[ThreadItem]:
     """Convert an app-server item payload into a typed SDK ThreadItem."""
-    from ..thread import Thread
-
     normalized_item = dict(item)
     normalized_item["type"] = _normalize_notification_item_type(item.get("type"))
 
@@ -609,8 +608,8 @@ def _notification_item_to_thread_item(item: Mapping[str, Any]) -> Optional[Threa
         normalized_item["text"] = normalized_item["content"]
 
     try:
-        return Thread._parse_item(cast(Any, None), normalized_item)
-    except Exception:
+        return parse_thread_item_payload(normalized_item)
+    except (CodexParseError, KeyError, TypeError, ValueError):
         return None
 
 
@@ -1352,119 +1351,128 @@ class CodexModel(Model):
         """Execute one app-server turn and parse it into PydanticAI parts."""
         client = await self._ensure_client()
         session = await client.turn_session(thread_id, prompt)
-        state = _TurnAccumulationState()
-        hook_state = _HookDispatchState()
+        try:
+            state = _TurnAccumulationState()
+            hook_state = _HookDispatchState()
 
-        allow_stream_text = bool(
-            streamed is not None and model_request_parameters.allow_text_output
-        )
-        stream_raw_text = bool(
-            allow_stream_text
-            and not model_request_parameters.function_tools
-            and not model_request_parameters.output_tools
-        )
-
-        if hooks is not None:
-            hook_state.turn_started = True
-            await dispatch_event(hooks, TurnStartedEvent(type="turn.started"))
-
-        async for notification in session.notifications():
-            self._handle_notification(
-                notification=notification,
-                state=state,
-                streamed=streamed,
-                allow_stream_text=allow_stream_text,
-                stream_raw_text=stream_raw_text,
+            allow_stream_text = bool(
+                streamed is not None and model_request_parameters.allow_text_output
             )
-            await self._dispatch_notification_hooks(
-                notification=notification,
-                hooks=hooks,
-                hook_state=hook_state,
+            stream_raw_text = bool(
+                allow_stream_text
+                and not model_request_parameters.function_tools
+                and not model_request_parameters.output_tools
             )
 
-        final_turn = await session.wait()
-        if state.turn_failed_message:
-            raise TurnFailedError(state.turn_failed_message)
+            if hooks is not None:
+                hook_state.turn_started = True
+                await dispatch_event(hooks, TurnStartedEvent(type="turn.started"))
 
-        usage = state.usage or _extract_usage_from_turn(final_turn) or RequestUsage()
-        if hooks is not None and not hook_state.turn_completed:
-            hook_state.turn_completed = True
-            await dispatch_event(
-                hooks,
-                TurnCompletedEvent(
-                    type="turn.completed",
-                    usage=_request_usage_to_thread_usage(usage),
-                ),
-            )
-        final_text = _extract_turn_text(final_turn)
-        if not final_text:
-            final_text = state.latest_agent_text
-
-        parsed_json = _extract_envelope(final_text) if final_text else None
-        parsed_envelope = parsed_json if _is_envelope_candidate(parsed_json) else None
-
-        parts: List[Any] = []
-        tool_calls = _tool_calls_from_envelope(parsed_envelope)
-        if tool_calls:
-            for index, call in enumerate(tool_calls):
-                parts.append(
-                    ToolCallPart(
-                        tool_name=call.tool_name,
-                        args=call.arguments_json,
-                        tool_call_id=call.tool_call_id,
-                    )
+            async for notification in session.notifications():
+                self._handle_notification(
+                    notification=notification,
+                    state=state,
+                    streamed=streamed,
+                    allow_stream_text=allow_stream_text,
+                    stream_raw_text=stream_raw_text,
                 )
-                if streamed is not None:
-                    if call.tool_call_id in state.streamed_tool_call_ids:
-                        continue
-                    vendor_part_id = state.tool_call_vendor_part_ids.get(
-                        call.tool_call_id, index
-                    )
-                    streamed.push_tool_call(
-                        vendor_part_id=vendor_part_id,
-                        tool_name=call.tool_name,
-                        args=call.arguments_json,
-                        tool_call_id=call.tool_call_id,
-                    )
-            return parts, usage
+                await self._dispatch_notification_hooks(
+                    notification=notification,
+                    hooks=hooks,
+                    hook_state=hook_state,
+                )
 
-        if parsed_envelope is not None:
-            final_value = _final_from_envelope(parsed_envelope)
-        else:
-            final_value = final_text
+            final_turn = await session.wait()
+            if state.turn_failed_message:
+                raise TurnFailedError(state.turn_failed_message)
 
-        if model_request_parameters.allow_text_output and final_value:
-            parts.append(TextPart(final_value))
-            if streamed is not None:
-                if allow_stream_text:
-                    if not state.item_text_by_id:
-                        streamed.push_text_delta(vendor_part_id=0, content=final_value)
-                    else:
-                        last_item_id = (
-                            state.last_updated_item_id
-                            if state.last_updated_item_id in state.item_text_by_id
-                            else next(reversed(state.item_text_by_id))
+            usage = (
+                state.usage or _extract_usage_from_turn(final_turn) or RequestUsage()
+            )
+            if hooks is not None and not hook_state.turn_completed:
+                hook_state.turn_completed = True
+                await dispatch_event(
+                    hooks,
+                    TurnCompletedEvent(
+                        type="turn.completed",
+                        usage=_request_usage_to_thread_usage(usage),
+                    ),
+                )
+            final_text = _extract_turn_text(final_turn)
+            if not final_text:
+                final_text = state.latest_agent_text
+
+            parsed_json = _extract_envelope(final_text) if final_text else None
+            parsed_envelope = (
+                parsed_json if _is_envelope_candidate(parsed_json) else None
+            )
+
+            parts: List[Any] = []
+            tool_calls = _tool_calls_from_envelope(parsed_envelope)
+            if tool_calls:
+                for index, call in enumerate(tool_calls):
+                    parts.append(
+                        ToolCallPart(
+                            tool_name=call.tool_name,
+                            args=call.arguments_json,
+                            tool_call_id=call.tool_call_id,
                         )
-                        last_text = state.item_text_by_id[last_item_id]
-                        if final_value.startswith(last_text):
-                            remainder = final_value[len(last_text) :]
-                            if remainder:
-                                vendor_part_id = state.vendor_part_ids.get(
-                                    last_item_id, 0
-                                )
-                                streamed.push_text_delta(
-                                    vendor_part_id=vendor_part_id,
-                                    content=remainder,
-                                )
-                        elif final_value != last_text:
-                            streamed.push_text_delta(
-                                vendor_part_id=state.next_vendor_part_id,
-                                content=final_value,
-                            )
-                else:
-                    streamed.push_text_delta(vendor_part_id=0, content=final_value)
+                    )
+                    if streamed is not None:
+                        if call.tool_call_id in state.streamed_tool_call_ids:
+                            continue
+                        vendor_part_id = state.tool_call_vendor_part_ids.get(
+                            call.tool_call_id, index
+                        )
+                        streamed.push_tool_call(
+                            vendor_part_id=vendor_part_id,
+                            tool_name=call.tool_name,
+                            args=call.arguments_json,
+                            tool_call_id=call.tool_call_id,
+                        )
+                return parts, usage
 
-        return parts, usage
+            if parsed_envelope is not None:
+                final_value = _final_from_envelope(parsed_envelope)
+            else:
+                final_value = final_text
+
+            if model_request_parameters.allow_text_output and final_value:
+                parts.append(TextPart(final_value))
+                if streamed is not None:
+                    if allow_stream_text:
+                        if not state.item_text_by_id:
+                            streamed.push_text_delta(
+                                vendor_part_id=0, content=final_value
+                            )
+                        else:
+                            last_item_id = (
+                                state.last_updated_item_id
+                                if state.last_updated_item_id in state.item_text_by_id
+                                else next(reversed(state.item_text_by_id))
+                            )
+                            last_text = state.item_text_by_id[last_item_id]
+                            if final_value.startswith(last_text):
+                                remainder = final_value[len(last_text) :]
+                                if remainder:
+                                    vendor_part_id = state.vendor_part_ids.get(
+                                        last_item_id, 0
+                                    )
+                                    streamed.push_text_delta(
+                                        vendor_part_id=vendor_part_id,
+                                        content=remainder,
+                                    )
+                            elif final_value != last_text:
+                                streamed.push_text_delta(
+                                    vendor_part_id=state.next_vendor_part_id,
+                                    content=final_value,
+                                )
+                    else:
+                        streamed.push_text_delta(vendor_part_id=0, content=final_value)
+
+            return parts, usage
+        finally:
+            await session.close()
 
     async def _run_codex_request(
         self,
@@ -1580,10 +1588,11 @@ class CodexModel(Model):
                     )
                     streamed.finish(usage=usage, thread_id=thread_id, parts=parts)
                 except Exception as exc:  # pragma: no cover - defensive
+                    failed_thread_id = self._thread_id or thread_id
                     self._thread_id = None
                     self._active_thread_reasoning_effort = None
                     self._messages_seen = 0
-                    streamed.finish(thread_id=thread_id, error=exc)
+                    streamed.finish(thread_id=failed_thread_id, error=exc)
 
             task = asyncio.create_task(_runner())
             try:

--- a/src/codex_sdk/thread.py
+++ b/src/codex_sdk/thread.py
@@ -46,6 +46,145 @@ T = TypeVar("T")
 _MODEL_REASONING_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
 
 
+def parse_thread_item_payload(data: Mapping[str, Any]) -> ThreadItem:
+    """Convert an item payload mapping into the corresponding typed ThreadItem."""
+    from .items import (
+        AgentMessageItem,
+        CollabAgentState,
+        CollabAgentStatus,
+        CollabToolCallItem,
+        CommandExecutionItem,
+        ErrorItem,
+        FileChangeItem,
+        FileUpdateChange,
+        McpToolCallItem,
+        McpToolCallItemError,
+        McpToolCallItemResult,
+        ReasoningItem,
+        TodoItem,
+        TodoListItem,
+        WebSearchItem,
+    )
+
+    item_type = data.get("type")
+
+    if item_type == "agent_message":
+        return AgentMessageItem(id=data["id"], type="agent_message", text=data["text"])
+    elif item_type == "reasoning":
+        return ReasoningItem(id=data["id"], type="reasoning", text=data["text"])
+    elif item_type == "command_execution":
+        return CommandExecutionItem(
+            id=data["id"],
+            type="command_execution",
+            command=data["command"],
+            aggregated_output=data["aggregated_output"],
+            exit_code=data.get("exit_code"),
+            status=data["status"],
+        )
+    elif item_type == "file_change":
+        changes = [
+            FileUpdateChange(path=change["path"], kind=change["kind"])
+            for change in data["changes"]
+        ]
+        return FileChangeItem(
+            id=data["id"],
+            type="file_change",
+            changes=changes,
+            status=data["status"],
+        )
+    elif item_type == "mcp_tool_call":
+        result_data = data.get("result")
+        result = None
+        if isinstance(result_data, dict):
+            content = result_data.get("content", [])
+            structured_content = result_data.get("structured_content")
+            result = McpToolCallItemResult(
+                content=list(content) if isinstance(content, list) else [],
+                structured_content=structured_content,
+            )
+
+        error_data = data.get("error")
+        error = None
+        if isinstance(error_data, dict) and "message" in error_data:
+            error = McpToolCallItemError(message=str(error_data["message"]))
+
+        return McpToolCallItem(
+            id=data["id"],
+            type="mcp_tool_call",
+            server=data["server"],
+            tool=data["tool"],
+            status=data["status"],
+            arguments=data.get("arguments"),
+            result=result,
+            error=error,
+        )
+    elif item_type == "collab_tool_call":
+        raw_receiver_ids = data.get("receiver_thread_ids")
+        receiver_thread_ids: List[str] = []
+        if isinstance(raw_receiver_ids, list):
+            receiver_thread_ids = [
+                str(entry) for entry in raw_receiver_ids if isinstance(entry, str)
+            ]
+
+        raw_agents_states = data.get("agents_states")
+        agents_states: Dict[str, CollabAgentState] = {}
+        if isinstance(raw_agents_states, dict):
+            for key, value in raw_agents_states.items():
+                if not isinstance(key, str) or not isinstance(value, dict):
+                    continue
+                status = value.get("status")
+                if not isinstance(status, str):
+                    continue
+                message = value.get("message")
+                agents_states[key] = CollabAgentState(
+                    status=cast(CollabAgentStatus, status),
+                    message=message if isinstance(message, str) else None,
+                )
+
+        prompt = data.get("prompt")
+        model = data.get("model")
+        reasoning_effort = data.get("reasoning_effort")
+        if not isinstance(reasoning_effort, str):
+            alt_reasoning_effort = data.get("reasoningEffort")
+            reasoning_effort = (
+                alt_reasoning_effort if isinstance(alt_reasoning_effort, str) else None
+            )
+        if reasoning_effort not in _MODEL_REASONING_EFFORTS:
+            reasoning_effort = None
+        return CollabToolCallItem(
+            id=data["id"],
+            type="collab_tool_call",
+            tool=data["tool"],
+            sender_thread_id=data["sender_thread_id"],
+            receiver_thread_ids=receiver_thread_ids,
+            prompt=prompt if isinstance(prompt, str) else None,
+            model=model if isinstance(model, str) else None,
+            reasoning_effort=cast(Optional[ModelReasoningEffort], reasoning_effort),
+            agents_states=agents_states,
+            status=data["status"],
+        )
+    elif item_type == "web_search":
+        query = data.get("query", "")
+        if not isinstance(query, str):
+            query = ""
+        return WebSearchItem(
+            id=data["id"],
+            type="web_search",
+            query=query,
+            action=data.get("action"),
+        )
+    elif item_type == "todo_list":
+        items = [
+            TodoItem(text=item["text"], completed=item["completed"])
+            for item in data["items"]
+        ]
+        return TodoListItem(id=data["id"], type="todo_list", items=items)
+    elif item_type == "error":
+        return ErrorItem(id=data["id"], type="error", message=data["message"])
+    else:
+        raise CodexParseError(f"Unknown item type: {item_type}")
+
+
 @dataclass
 class Turn:
     """Completed turn."""
@@ -426,145 +565,7 @@ class Thread:
         Raises:
             CodexParseError: If the item's "type" is not recognized.
         """
-        from .items import (
-            AgentMessageItem,
-            CollabAgentState,
-            CollabAgentStatus,
-            CollabToolCallItem,
-            CommandExecutionItem,
-            ErrorItem,
-            FileChangeItem,
-            FileUpdateChange,
-            McpToolCallItem,
-            McpToolCallItemError,
-            McpToolCallItemResult,
-            ReasoningItem,
-            TodoItem,
-            TodoListItem,
-            WebSearchItem,
-        )
-
-        item_type = data.get("type")
-
-        if item_type == "agent_message":
-            return AgentMessageItem(
-                id=data["id"], type="agent_message", text=data["text"]
-            )
-        elif item_type == "reasoning":
-            return ReasoningItem(id=data["id"], type="reasoning", text=data["text"])
-        elif item_type == "command_execution":
-            return CommandExecutionItem(
-                id=data["id"],
-                type="command_execution",
-                command=data["command"],
-                aggregated_output=data["aggregated_output"],
-                exit_code=data.get("exit_code"),
-                status=data["status"],
-            )
-        elif item_type == "file_change":
-            changes = [
-                FileUpdateChange(path=change["path"], kind=change["kind"])
-                for change in data["changes"]
-            ]
-            return FileChangeItem(
-                id=data["id"],
-                type="file_change",
-                changes=changes,
-                status=data["status"],
-            )
-        elif item_type == "mcp_tool_call":
-            result_data = data.get("result")
-            result = None
-            if isinstance(result_data, dict):
-                content = result_data.get("content", [])
-                structured_content = result_data.get("structured_content")
-                result = McpToolCallItemResult(
-                    content=list(content) if isinstance(content, list) else [],
-                    structured_content=structured_content,
-                )
-
-            error_data = data.get("error")
-            error = None
-            if isinstance(error_data, dict) and "message" in error_data:
-                error = McpToolCallItemError(message=str(error_data["message"]))
-
-            return McpToolCallItem(
-                id=data["id"],
-                type="mcp_tool_call",
-                server=data["server"],
-                tool=data["tool"],
-                status=data["status"],
-                arguments=data.get("arguments"),
-                result=result,
-                error=error,
-            )
-        elif item_type == "collab_tool_call":
-            raw_receiver_ids = data.get("receiver_thread_ids")
-            receiver_thread_ids: List[str] = []
-            if isinstance(raw_receiver_ids, list):
-                receiver_thread_ids = [
-                    str(entry) for entry in raw_receiver_ids if isinstance(entry, str)
-                ]
-
-            raw_agents_states = data.get("agents_states")
-            agents_states: Dict[str, CollabAgentState] = {}
-            if isinstance(raw_agents_states, dict):
-                for key, value in raw_agents_states.items():
-                    if not isinstance(key, str) or not isinstance(value, dict):
-                        continue
-                    status = value.get("status")
-                    if not isinstance(status, str):
-                        continue
-                    message = value.get("message")
-                    agents_states[key] = CollabAgentState(
-                        status=cast(CollabAgentStatus, status),
-                        message=message if isinstance(message, str) else None,
-                    )
-
-            prompt = data.get("prompt")
-            model = data.get("model")
-            reasoning_effort = data.get("reasoning_effort")
-            if not isinstance(reasoning_effort, str):
-                alt_reasoning_effort = data.get("reasoningEffort")
-                reasoning_effort = (
-                    alt_reasoning_effort
-                    if isinstance(alt_reasoning_effort, str)
-                    else None
-                )
-            if reasoning_effort not in _MODEL_REASONING_EFFORTS:
-                reasoning_effort = None
-            return CollabToolCallItem(
-                id=data["id"],
-                type="collab_tool_call",
-                tool=data["tool"],
-                sender_thread_id=data["sender_thread_id"],
-                receiver_thread_ids=receiver_thread_ids,
-                prompt=prompt if isinstance(prompt, str) else None,
-                model=model if isinstance(model, str) else None,
-                reasoning_effort=cast(Optional[ModelReasoningEffort], reasoning_effort),
-                agents_states=agents_states,
-                status=data["status"],
-            )
-        elif item_type == "web_search":
-            query = data.get("query", "")
-            if not isinstance(query, str):
-                query = ""
-            return WebSearchItem(
-                id=data["id"],
-                type="web_search",
-                query=query,
-                action=data.get("action"),
-            )
-        elif item_type == "todo_list":
-            items = [
-                TodoItem(text=item["text"], completed=item["completed"])
-                for item in data["items"]
-            ]
-            return TodoListItem(id=data["id"], type="todo_list", items=items)
-        elif item_type == "error":
-            return ErrorItem(id=data["id"], type="error", message=data["message"])
-        else:
-            raise CodexParseError(f"Unknown item type: {item_type}")
+        return parse_thread_item_payload(data)
 
     async def run(
         self, input: Input, turn_options: Optional[TurnOptions] = None

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -159,7 +159,14 @@ async def test_app_server_initialize_with_experimental_capabilities(
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
 
     client = AppServerClient(
-        AppServerOptions(auto_initialize=False, experimental_api_enabled=True)
+        AppServerOptions(
+            auto_initialize=False,
+            experimental_api_enabled=True,
+            opt_out_notification_methods=[
+                "thread/started",
+                "item/agentMessage/delta",
+            ],
+        )
     )
     await client.start()
 
@@ -167,7 +174,13 @@ async def test_app_server_initialize_with_experimental_capabilities(
     await asyncio.sleep(0)
     init_request = json.loads(process.stdin.writes[-1].decode("utf-8"))
     assert init_request["method"] == "initialize"
-    assert init_request["params"]["capabilities"] == {"experimentalApi": True}
+    assert init_request["params"]["capabilities"] == {
+        "experimentalApi": True,
+        "optOutNotificationMethods": [
+            "thread/started",
+            "item/agentMessage/delta",
+        ],
+    }
 
     stdout.feed('{"id":1,"result":{"userAgent":"codex"}}')
     _ = await init_task
@@ -354,6 +367,8 @@ async def test_app_server_methods_and_input_normalization(
             model_providers=["openai"],
             source_kinds=["cli"],
             archived=True,
+            cwd=tmp_path,
+            search_term="bugfix",
         )
     )
     _, payload = await expect_request(
@@ -363,6 +378,8 @@ async def test_app_server_methods_and_input_normalization(
     assert payload["params"]["modelProviders"] == ["openai"]
     assert payload["params"]["sourceKinds"] == ["cli"]
     assert payload["params"]["archived"] is True
+    assert payload["params"]["cwd"] == str(tmp_path)
+    assert payload["params"]["searchTerm"] == "bugfix"
 
     # Cover thread_list with no filters (params should be omitted).
     task = asyncio.create_task(client.thread_list())
@@ -393,6 +410,19 @@ async def test_app_server_methods_and_input_normalization(
 
     task = asyncio.create_task(client.thread_compact_start("t1"))
     _, payload = await expect_request(task, "thread/compact/start", {})
+    assert payload["params"] == {"threadId": "t1"}
+
+    task = asyncio.create_task(
+        client.thread_shell_command("t1", command="git status --short")
+    )
+    _, payload = await expect_request(task, "thread/shellCommand", {})
+    assert payload["params"] == {
+        "threadId": "t1",
+        "command": "git status --short",
+    }
+
+    task = asyncio.create_task(client.thread_background_terminals_clean("t1"))
+    _, payload = await expect_request(task, "thread/backgroundTerminals/clean", {})
     assert payload["params"] == {"threadId": "t1"}
 
     task = asyncio.create_task(client.thread_rollback("t1", num_turns=2))
@@ -435,11 +465,13 @@ async def test_app_server_methods_and_input_normalization(
         client.config_batch_write(
             edits=[
                 {"keyPath": "analytics.enabled", "value": True, "mergeStrategy": "set"}
-            ]
+            ],
+            reload_user_config=True,
         )
     )
     _, payload = await expect_request(task, "config/batchWrite", {"ok": True})
     assert isinstance(payload["params"]["edits"], list)
+    assert payload["params"]["reloadUserConfig"] is True
 
     task = asyncio.create_task(client.skills_list(cwds=[tmp_path], force_reload=True))
     _, payload = await expect_request(task, "skills/list", {"data": []})
@@ -579,13 +611,28 @@ async def test_app_server_methods_and_input_normalization(
     _, payload = await expect_request(task, "experimentalFeature/list", {"data": []})
     assert payload["params"] == {"limit": 5, "cursor": "e"}
 
+    task = asyncio.create_task(
+        client.experimental_feature_enablement_set(
+            feature_enablement={"apps": True, "plugins": False}
+        )
+    )
+    _, payload = await expect_request(
+        task, "experimentalFeature/enablement/set", {"ok": True}
+    )
+    assert payload["params"] == {"featureEnablement": {"apps": True, "plugins": False}}
+
     task = asyncio.create_task(client.collaboration_mode_list())
     _, payload = await expect_request(task, "collaborationMode/list", {"data": []})
     assert payload["params"] == {}
 
-    task = asyncio.create_task(client.plugin_list(cwds=[tmp_path]))
+    task = asyncio.create_task(
+        client.plugin_list(cwds=[tmp_path], force_remote_sync=True)
+    )
     _, payload = await expect_request(task, "plugin/list", {"marketplaces": []})
-    assert payload["params"] == {"cwds": [str(tmp_path)]}
+    assert payload["params"] == {
+        "cwds": [str(tmp_path)],
+        "forceRemoteSync": True,
+    }
 
     task = asyncio.create_task(
         client.plugin_install(
@@ -702,6 +749,16 @@ async def test_app_server_methods_and_input_normalization(
         "path": str(tmp_path / "source.txt"),
         "dataBase64": "aGk=",
     }
+
+    task = asyncio.create_task(client.fs_watch(path=tmp_path))
+    _, payload = await expect_request(
+        task, "fs/watch", {"watchId": "watch_1", "path": str(tmp_path)}
+    )
+    assert payload["params"] == {"path": str(tmp_path)}
+
+    task = asyncio.create_task(client.fs_unwatch(watch_id="watch_1"))
+    _, payload = await expect_request(task, "fs/unwatch", {})
+    assert payload["params"] == {"watchId": "watch_1"}
 
     task = asyncio.create_task(
         client.command_exec(
@@ -829,11 +886,13 @@ async def test_app_server_methods_and_input_normalization(
         ]
     }
 
-    task = asyncio.create_task(client.windows_sandbox_setup_start(mode="elevated"))
+    task = asyncio.create_task(
+        client.windows_sandbox_setup_start(mode="elevated", cwd=tmp_path)
+    )
     _, payload = await expect_request(
         task, "windowsSandbox/setupStart", {"status": "started"}
     )
-    assert payload["params"] == {"mode": "elevated"}
+    assert payload["params"] == {"mode": "elevated", "cwd": str(tmp_path)}
 
     task = asyncio.create_task(
         client.account_login_start(params={"type": "apiKey", "apiKey": "key"})

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -188,6 +188,36 @@ async def test_app_server_initialize_with_experimental_capabilities(
 
 
 @pytest.mark.asyncio
+async def test_app_server_initialize_rejects_required_lifecycle_opt_outs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stdout = QueueStream()
+    process = FakeProcess(stdout)
+
+    async def fake_spawn(*_cmd: Any, **_kwargs: Any) -> FakeProcess:
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
+
+    client = AppServerClient(
+        AppServerOptions(
+            auto_initialize=False,
+            opt_out_notification_methods=["turn/completed", "item/agentMessage/delta"],
+        )
+    )
+    await client.start()
+
+    with pytest.raises(
+        CodexError,
+        match="opt_out_notification_methods cannot suppress required turn lifecycle notifications",
+    ):
+        await client.initialize()
+
+    assert process.stdin.writes == []
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_app_server_initialize_starts_process_when_needed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_pydantic_ai_model.py
+++ b/tests/test_pydantic_ai_model.py
@@ -399,6 +399,16 @@ async def test_codex_model_dispatches_typed_hooks_for_camel_case_item_types():
     ]
 
 
+def test_notification_item_to_thread_item_returns_none_for_invalid_payload():
+    invalid_payload = {"id": "cmd-1", "type": "commandExecution"}
+
+    from codex_sdk.integrations.pydantic_ai_model import (
+        _notification_item_to_thread_item,
+    )
+
+    assert _notification_item_to_thread_item(invalid_payload) is None
+
+
 @pytest.mark.asyncio
 async def test_codex_model_dispatches_turn_failed_hook_before_raising():
     app = FakeAppServerClient(
@@ -428,6 +438,32 @@ async def test_codex_model_dispatches_turn_failed_hook_before_raising():
         )
 
     assert seen == ["thread.started", "turn.started", "turn.failed"]
+
+
+@pytest.mark.asyncio
+async def test_codex_model_closes_turn_session_when_hook_dispatch_fails():
+    def _raise_on_turn_started(_event):
+        raise RuntimeError("hook boom")
+
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-hook-close",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": "hello",
+        },
+    )
+    model = CodexModel(
+        app_server=app,
+        hooks=ThreadHooks(on_turn_started=_raise_on_turn_started),
+    )
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    with pytest.raises(RuntimeError, match="hook boom"):
+        await model.request([ModelRequest(parts=[UserPromptPart("hi")])], None, params)
+
+    assert app.last_turn_session is not None
+    assert app.last_turn_session.close_calls == 1
 
 
 @pytest.mark.asyncio
@@ -928,6 +964,40 @@ async def test_codex_model_request_stream_uses_prepared_request_parameters():
 
 
 @pytest.mark.asyncio
+async def test_codex_model_request_stream_preserves_thread_id_on_failure():
+    class FailingTurnSessionApp(FakeAppServerClient):
+        async def turn_session(self, thread_id, input, **params):
+            self.turn_session_calls.append(
+                {"thread_id": thread_id, "input": input, "params": dict(params)}
+            )
+            raise RuntimeError("stream boom")
+
+    app = FailingTurnSessionApp(
+        notifications=[],
+        final_turn={
+            "id": "turn-unused",
+            "usage": {"inputTokens": 1, "outputTokens": 0},
+            "finalResponse": "",
+        },
+        thread_id="thread-created",
+    )
+    model = CodexModel(app_server=app)
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+    streamed = None
+
+    with pytest.raises(RuntimeError, match="stream boom"):
+        async with model.request_stream(
+            [ModelRequest(parts=[UserPromptPart("fail")])], None, params
+        ) as current_streamed:
+            streamed = current_streamed
+            _ = [event async for event in current_streamed]
+
+    assert streamed is not None
+    assert streamed.provider_details == {"thread_id": "thread-created"}
+    assert streamed.get().provider_details == {"thread_id": "thread-created"}
+
+
+@pytest.mark.asyncio
 async def test_codex_model_request_stream_accepts_run_context_argument():
     app = FakeAppServerClient(
         notifications=[],
@@ -1101,6 +1171,7 @@ class FakeAppServerTurnSession:
     def __init__(self, notifications, final_turn):
         self._notifications = list(notifications)
         self._final_turn = dict(final_turn)
+        self.close_calls = 0
 
     async def notifications(self):
         for notification in self._notifications:
@@ -1108,6 +1179,9 @@ class FakeAppServerTurnSession:
 
     async def wait(self):
         return self._final_turn
+
+    async def close(self):
+        self.close_calls += 1
 
 
 class FakeAppServerClient:
@@ -1119,6 +1193,7 @@ class FakeAppServerClient:
         self.close_calls = 0
         self.thread_start_calls = []
         self.turn_session_calls = []
+        self.last_turn_session = None
 
     async def start(self):
         self.start_calls += 1
@@ -1134,7 +1209,10 @@ class FakeAppServerClient:
         self.turn_session_calls.append(
             {"thread_id": thread_id, "input": input, "params": dict(params)}
         )
-        return FakeAppServerTurnSession(self._notifications, self._final_turn)
+        self.last_turn_session = FakeAppServerTurnSession(
+            self._notifications, self._final_turn
+        )
+        return self.last_turn_session
 
 
 @pytest.mark.asyncio

--- a/tests/test_pydantic_ai_model.py
+++ b/tests/test_pydantic_ai_model.py
@@ -14,6 +14,7 @@ BaseModel = pydantic.BaseModel
 
 from codex_sdk.app_server import AppServerNotification, AppServerOptions
 from codex_sdk.exceptions import CodexError, TurnFailedError
+from codex_sdk.hooks import ThreadHooks
 from codex_sdk.integrations.pydantic_ai_model import (
     CodexModel,
     CodexStreamedResponse,
@@ -249,6 +250,184 @@ async def test_codex_model_returns_text_when_allowed():
     assert len(response.parts) == 1
     assert isinstance(response.parts[0], TextPart)
     assert response.parts[0].content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_codex_model_dispatches_typed_thread_hooks():
+    app = FakeAppServerClient(
+        notifications=[
+            AppServerNotification(
+                method="item/updated",
+                params={"item": {"id": "m1", "type": "agent_message", "text": "hello"}},
+            ),
+        ],
+        final_turn={
+            "id": "turn-hooks",
+            "usage": {"inputTokens": 2, "cachedInputTokens": 1, "outputTokens": 3},
+            "finalResponse": "hello",
+        },
+        thread_id="thread-hooks",
+    )
+
+    seen = []
+    seen_items = []
+
+    model = CodexModel(
+        app_server=app,
+        hooks=ThreadHooks(
+            on_event=lambda event: seen.append(event.type),
+            on_item=lambda item: seen_items.append(
+                (item.type, getattr(item, "text", ""))
+            ),
+        ),
+    )
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    response = await model.request(
+        [ModelRequest(parts=[UserPromptPart("hi")])], None, params
+    )
+
+    assert response.parts and isinstance(response.parts[0], TextPart)
+    assert seen == [
+        "thread.started",
+        "turn.started",
+        "item.updated",
+        "turn.completed",
+    ]
+    assert seen_items == [("agent_message", "hello")]
+
+
+@pytest.mark.asyncio
+async def test_codex_model_dispatches_typed_hooks_for_camel_case_item_types():
+    app = FakeAppServerClient(
+        notifications=[
+            AppServerNotification(
+                method="item/updated",
+                params={
+                    "item": {
+                        "id": "cmd-1",
+                        "type": "commandExecution",
+                        "command": "pwd",
+                        "aggregated_output": "/tmp",
+                        "status": "completed",
+                    }
+                },
+            ),
+            AppServerNotification(
+                method="item/updated",
+                params={
+                    "item": {
+                        "id": "patch-1",
+                        "type": "fileChange",
+                        "changes": [{"path": "README.md", "kind": "update"}],
+                        "status": "completed",
+                    }
+                },
+            ),
+            AppServerNotification(
+                method="item/updated",
+                params={
+                    "item": {
+                        "id": "mcp-1",
+                        "type": "mcpToolCall",
+                        "server": "docs",
+                        "tool": "search",
+                        "status": "completed",
+                    }
+                },
+            ),
+            AppServerNotification(
+                method="item/updated",
+                params={
+                    "item": {
+                        "id": "search-1",
+                        "type": "webSearch",
+                        "query": "codex sdk",
+                    }
+                },
+            ),
+            AppServerNotification(
+                method="item/updated",
+                params={
+                    "item": {
+                        "id": "todo-1",
+                        "type": "todoList",
+                        "items": [{"text": "write tests", "completed": False}],
+                    }
+                },
+            ),
+            AppServerNotification(
+                method="item/updated",
+                params={
+                    "item": {
+                        "id": "collab-1",
+                        "type": "collabToolCall",
+                        "tool": "wait_agent",
+                        "sender_thread_id": "thread-a",
+                        "receiver_thread_ids": ["thread-b"],
+                        "status": "completed",
+                    }
+                },
+            ),
+        ],
+        final_turn={
+            "id": "turn-camel-items",
+            "usage": {"inputTokens": 2, "outputTokens": 1},
+            "finalResponse": "done",
+        },
+    )
+
+    seen_items = []
+    model = CodexModel(
+        app_server=app,
+        hooks=ThreadHooks(on_item=lambda item: seen_items.append(item.type)),
+    )
+
+    await model.request(
+        [ModelRequest(parts=[UserPromptPart("hi")])],
+        None,
+        ModelRequestParameters(output_mode="text", allow_text_output=True),
+    )
+
+    assert seen_items == [
+        "command_execution",
+        "file_change",
+        "mcp_tool_call",
+        "web_search",
+        "todo_list",
+        "collab_tool_call",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_codex_model_dispatches_turn_failed_hook_before_raising():
+    app = FakeAppServerClient(
+        notifications=[
+            AppServerNotification(
+                method="turn/failed",
+                params={"error": {"message": "approval denied"}},
+            )
+        ],
+        final_turn={
+            "id": "turn-failed-hook",
+            "usage": {"inputTokens": 1, "outputTokens": 0},
+            "finalResponse": "",
+        },
+    )
+
+    seen = []
+    model = CodexModel(
+        app_server=app,
+        hooks=ThreadHooks(on_event=lambda event: seen.append(event.type)),
+    )
+    params = ModelRequestParameters(output_mode="text", allow_text_output=True)
+
+    with pytest.raises(TurnFailedError, match="approval denied"):
+        await model.request(
+            [ModelRequest(parts=[UserPromptPart("fail")])], None, params
+        )
+
+    assert seen == ["thread.started", "turn.started", "turn.failed"]
 
 
 @pytest.mark.asyncio
@@ -544,6 +723,128 @@ async def test_codex_model_includes_tool_manifest_and_history_in_prompt():
 
 
 @pytest.mark.asyncio
+async def test_codex_model_uses_base_prepare_request_customization():
+    class CustomizingCodexModel(CodexModel):
+        def customize_request_parameters(self, model_request_parameters):
+            return dataclasses.replace(
+                model_request_parameters,
+                allow_text_output=False,
+            )
+
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-customize-prepare",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": ""}),
+        },
+    )
+    model = CustomizingCodexModel(app_server=app)
+
+    await model.request(
+        [ModelRequest(parts=[UserPromptPart("hi")])],
+        None,
+        ModelRequestParameters(output_mode="text", allow_text_output=True),
+    )
+
+    prompt = app.turn_session_calls[0]["input"]
+    assert "Text output is NOT allowed" in prompt
+
+
+@pytest.mark.asyncio
+async def test_codex_model_default_profile_maps_thinking_to_thread_reasoning_effort():
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-thinking-map",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "ok"}),
+        },
+    )
+    model = CodexModel(app_server=app)
+
+    await model.request(
+        [ModelRequest(parts=[UserPromptPart("hi")])],
+        {"thinking": "low"},
+        ModelRequestParameters(output_mode="text", allow_text_output=True),
+    )
+
+    assert app.thread_start_calls[0]["model_reasoning_effort"] == "low"
+
+
+@pytest.mark.asyncio
+async def test_codex_model_explicit_thread_reasoning_effort_wins():
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-thinking-explicit",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "ok"}),
+        },
+    )
+    model = CodexModel(
+        app_server=app,
+        thread_options=ThreadOptions(model_reasoning_effort="high"),
+    )
+
+    await model.request(
+        [ModelRequest(parts=[UserPromptPart("hi")])],
+        {"thinking": "low"},
+        ModelRequestParameters(output_mode="text", allow_text_output=True),
+    )
+
+    assert app.thread_start_calls[0]["model_reasoning_effort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_codex_model_thinking_true_keeps_provider_default_reasoning_effort():
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-thinking-default",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "ok"}),
+        },
+    )
+    model = CodexModel(app_server=app)
+
+    await model.request(
+        [ModelRequest(parts=[UserPromptPart("hi")])],
+        {"thinking": True},
+        ModelRequestParameters(output_mode="text", allow_text_output=True),
+    )
+
+    assert "model_reasoning_effort" not in app.thread_start_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_codex_model_rejects_unsupported_builtin_tools():
+    builtin_tools = importlib.import_module("pydantic_ai.builtin_tools")
+    exceptions = importlib.import_module("pydantic_ai.exceptions")
+
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-builtin-tool",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json({"tool_calls": [], "final": "ok"}),
+        },
+    )
+    model = CodexModel(app_server=app)
+
+    with pytest.raises(exceptions.UserError, match="Builtin tool"):
+        await model.request(
+            [ModelRequest(parts=[UserPromptPart("hi")])],
+            None,
+            ModelRequestParameters(
+                output_mode="text",
+                allow_text_output=True,
+                builtin_tools=[builtin_tools.WebSearchTool()],
+            ),
+        )
+
+
+@pytest.mark.asyncio
 async def test_codex_model_request_stream_yields_response():
     app = FakeAppServerClient(
         notifications=[],
@@ -569,6 +870,61 @@ async def test_codex_model_request_stream_yields_response():
     assert response.parts[0].content == "hello"
     assert response.provider_name == "openai"
     assert response.provider_details == {"thread_id": "thread-123"}
+
+
+@pytest.mark.asyncio
+async def test_codex_model_request_stream_uses_prepared_request_parameters():
+    class OutputToolStreamingCodexModel(CodexModel):
+        def customize_request_parameters(self, model_request_parameters):
+            return dataclasses.replace(
+                model_request_parameters,
+                output_mode="tool",
+                output_tools=[
+                    ToolDefinition(
+                        name="final_tool",
+                        description="Finish the run",
+                        kind="output",
+                        parameters_json_schema={
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": False,
+                        },
+                    )
+                ],
+                allow_text_output=False,
+            )
+
+    app = FakeAppServerClient(
+        notifications=[],
+        final_turn={
+            "id": "turn-stream-prepare",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+            "finalResponse": _envelope_json(
+                {
+                    "tool_calls": [
+                        {"id": "call-1", "name": "final_tool", "arguments": "{}"}
+                    ],
+                    "final": "",
+                }
+            ),
+        },
+    )
+    model = OutputToolStreamingCodexModel(app_server=app)
+
+    async with model.request_stream(
+        [ModelRequest(parts=[UserPromptPart("hi")])],
+        None,
+        ModelRequestParameters(output_mode="text", allow_text_output=True),
+    ) as streamed:
+        _ = [event async for event in streamed]
+        response = streamed.get()
+
+    assert streamed.final_result_event is not None
+    assert len(response.parts) == 1
+    assert isinstance(response.parts[0], ToolCallPart)
+    assert response.parts[0].tool_name == "final_tool"
+    prompt = app.turn_session_calls[0]["input"]
+    assert "Text output is NOT allowed" in prompt
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -769,7 +769,7 @@ wheels = [
 
 [[package]]
 name = "codex-sdk-python"
-version = "0.115.1"
+version = "0.117.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -814,7 +814,7 @@ dev = [
 requires-dist = [
     { name = "logfire-api", marker = "extra == 'logfire'", specifier = ">=4" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2" },
-    { name = "pydantic-ai", marker = "python_full_version >= '3.10' and extra == 'pydantic-ai'", specifier = ">=1.68.0,<2" },
+    { name = "pydantic-ai", marker = "python_full_version >= '3.10' and extra == 'pydantic-ai'", specifier = ">=1.73.0,<2" },
 ]
 provides-extras = ["pydantic", "pydantic-ai", "logfire"]
 
@@ -825,7 +825,7 @@ dev = [
     { name = "isort", specifier = ">=5.0" },
     { name = "mypy", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2" },
-    { name = "pydantic-ai", marker = "python_full_version >= '3.10'", specifier = ">=1.68.0,<2" },
+    { name = "pydantic-ai", marker = "python_full_version >= '3.10'", specifier = "==1.73.0" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=4.0" },
@@ -1690,6 +1690,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -2682,19 +2683,19 @@ wheels = [
 
 [[package]]
 name = "nexus-rpc"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/50/95d7bc91f900da5e22662c82d9bf0f72a4b01f2a552708bf2f43807707a1/nexus_rpc-1.2.0.tar.gz", hash = "sha256:b4ddaffa4d3996aaeadf49b80dfcdfbca48fe4cb616defaf3b3c5c2c8fc61890", size = 74142, upload-time = "2025-11-17T19:17:06.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/04/eaac430d0e6bf21265ae989427d37e94be5e41dc216879f1fbb6c5339942/nexus_rpc-1.2.0-py3-none-any.whl", hash = "sha256:977876f3af811ad1a09b2961d3d1ac9233bda43ff0febbb0c9906483b9d9f8a3", size = 28166, upload-time = "2025-11-17T19:17:05.64Z" },
+    { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
 ]
 
 [[package]]
 name = "openai"
-version = "2.26.0"
+version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
@@ -2706,9 +2707,9 @@ dependencies = [
     { name = "tqdm", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/91/2a06c4e9597c338cac1e5e5a8dd6f29e1836fc229c4c523529dca387fda8/openai-2.26.0.tar.gz", hash = "sha256:b41f37c140ae0034a6e92b0c509376d907f3a66109935fba2c1b471a7c05a8fb", size = 666702, upload-time = "2026-03-05T23:17:35.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/2e/3f73e8ca53718952222cacd0cf7eecc9db439d020f0c1fe7ae717e4e199a/openai-2.26.0-py3-none-any.whl", hash = "sha256:6151bf8f83802f036117f06cc8a57b3a4da60da9926826cc96747888b57f394f", size = 1136409, upload-time = "2026-03-05T23:17:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
 ]
 
 [[package]]
@@ -3246,19 +3247,19 @@ email = [
 
 [[package]]
 name = "pydantic-ai"
-version = "1.68.0"
+version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "temporal", "ui", "vertexai", "xai"], marker = "python_full_version >= '3.10'" },
+    { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "spec", "temporal", "ui", "vertexai", "xai"], marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/a7/562d14df67305a54c34bbde58b94e70790ba1486e125e9f6b7567a31e16f/pydantic_ai-1.68.0.tar.gz", hash = "sha256:9ecae11776b640096d75ca69eca6e122702c7e82f2924bf3a077b781a8d371f6", size = 12178, upload-time = "2026-03-13T03:39:06.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/f6/4fe7d179cbf55d0933bc3afaab14adb702cc7ff1bf876bac2a432eaf1dcb/pydantic_ai-1.73.0.tar.gz", hash = "sha256:11158b40a85b13a2f075680a9812929c9768c10771bcc27db1bfcceda59139e6", size = 12658, upload-time = "2026-03-27T03:49:47.614Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/97/8aa45378ff43b27b6505bd78c161ab3d2450d27b16b3f16622ad5edd315f/pydantic_ai-1.68.0-py3-none-any.whl", hash = "sha256:d4740389e3a9230934b1bd9f39880c07debad9f19d0ee3ab92ac28826b8612f5", size = 7226, upload-time = "2026-03-13T03:38:58.048Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/5d/34811942086587fc66ab62c10df2b029d994ef9c5578f23fc5403f143322/pydantic_ai-1.73.0-py3-none-any.whl", hash = "sha256:ec06153541fcb0ef5a69d314255284d22b395d9c71ce6b258c1987f9e255b6bc", size = 7551, upload-time = "2026-03-27T03:49:39.585Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.68.0"
+version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
@@ -3270,9 +3271,9 @@ dependencies = [
     { name = "pydantic-graph", marker = "python_full_version >= '3.10'" },
     { name = "typing-inspection", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/00/3e48684694e424a8d05dc1538fe53322854b0290fbb494f0007db62cd243/pydantic_ai_slim-1.68.0.tar.gz", hash = "sha256:38edda1dbe20137326903d8a223a9f4901d62b0a70799842cae3c7d60b3bebd2", size = 436924, upload-time = "2026-03-13T03:39:08.572Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1b/a5e18c7c721a3cfce5b17f86cb99e4142fcb70f38ea6d2b8963c2df445e1/pydantic_ai_slim-1.73.0.tar.gz", hash = "sha256:758d5bedb4b4f484c433672639bfc87af216a38453b1539ae10928a9ca62ff62", size = 497208, upload-time = "2026-03-27T03:49:49.459Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/14/4e850e54024b453ed905aa92b50b286ed9b096979e7d0896005be5e5b74c/pydantic_ai_slim-1.68.0-py3-none-any.whl", hash = "sha256:c3234c743ab256c7f26aecb2296428a55ae3db9f9ebb8d725941cae887e8e027", size = 567829, upload-time = "2026-03-13T03:39:00.91Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3b/6aa1874cd0ccbc83c17c8eb308834bf004c8d4344c27cd8048851d4b284d/pydantic_ai_slim-1.73.0-py3-none-any.whl", hash = "sha256:f7176ce6c78539e1070d7e22549186862c2f6e6ea8b05b3aaad8a1942ba1ff4f", size = 638701, upload-time = "2026-03-27T03:49:42.804Z" },
 ]
 
 [package.optional-dependencies]
@@ -3290,6 +3291,7 @@ cli = [
     { name = "argcomplete", marker = "python_full_version >= '3.10'" },
     { name = "prompt-toolkit", marker = "python_full_version >= '3.10'" },
     { name = "pyperclip", marker = "python_full_version >= '3.10'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 cohere = [
@@ -3325,6 +3327,10 @@ openai = [
 ]
 retries = [
     { name = "tenacity", marker = "python_full_version >= '3.10'" },
+]
+spec = [
+    { name = "pydantic-handlebars", marker = "python_full_version >= '3.10'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
 ]
 temporal = [
     { name = "temporalio", marker = "python_full_version >= '3.10'" },
@@ -3591,7 +3597,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "1.68.0"
+version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
@@ -3601,14 +3607,14 @@ dependencies = [
     { name = "pyyaml", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/8f/cd2bb2cea3d0e5f108b2aa1c32ecaa5bd74c48feb403f6e945c48ca4eb8d/pydantic_evals-1.68.0.tar.gz", hash = "sha256:f0a3318f7b0e35d4d9c065e2dbf36cfd850387d0a894e23c55390061b4d9b8fe", size = 56693, upload-time = "2026-03-13T03:39:09.724Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/45/ce1f9b97c4838f940c98693bc1d6298f0e1396355998942b095ce17157fe/pydantic_evals-1.73.0.tar.gz", hash = "sha256:c1f38ad9c4f566bee6958c92f205b8200957b4baf3dd5239e2a4a06edd28e3dc", size = 56137, upload-time = "2026-03-27T03:49:50.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/53/eb1aaf65be91c866b13daae38b6c4cdcf92afc2225b9d1bd6eaeb8b42abf/pydantic_evals-1.68.0-py3-none-any.whl", hash = "sha256:5f0f9596ddf6ae82ac48f83c5e346351b0a8b333b29ff971b20522d37243e95b", size = 67603, upload-time = "2026-03-13T03:39:02.632Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4e/aefc34a68adc165ddec22c0632cb3076579c46751ac11acdf8cec6462891/pydantic_evals-1.73.0-py3-none-any.whl", hash = "sha256:0609210d4825cc8339b5cb649be38321450b46d6e87d72c1ffde73598741fd5a", size = 67143, upload-time = "2026-03-27T03:49:44.298Z" },
 ]
 
 [[package]]
 name = "pydantic-graph"
-version = "1.68.0"
+version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx", marker = "python_full_version >= '3.10'" },
@@ -3616,9 +3622,21 @@ dependencies = [
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "typing-inspection", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/75/de53b774d7b96adc7a75ddc4cac4dfaea25d5538b5004710fc1e9a74180c/pydantic_graph-1.68.0.tar.gz", hash = "sha256:fa48d15659e9514393f0596f62a0355783309e725deedb14d8f3e68fccf3974a", size = 58534, upload-time = "2026-03-13T03:39:10.896Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/22/d479ea32e3c712c6711e41157fb975d81582e5171510e4c662f21a85e9fe/pydantic_graph-1.73.0.tar.gz", hash = "sha256:f0d3e4984af1d902cdda1ccd3fcd86949d45d3ed21559e781f7cf9eace2ed914", size = 58717, upload-time = "2026-03-27T03:49:51.967Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/bf/cd45f1987468679e8d631d1c0e6014c4156815440a985389bd11aeb4465f/pydantic_graph-1.68.0-py3-none-any.whl", hash = "sha256:a563291109c3efb69fe7553f20b164651fe98680252e8f07a3cd9a1db2f8a879", size = 72350, upload-time = "2026-03-13T03:39:04.439Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/4cc0b1c543b8a0c1f9add7bdeb2e8cd583961a795664a1a74d1fc8200416/pydantic_graph-1.73.0-py3-none-any.whl", hash = "sha256:aaab8b1580885f5108401db0a7da58d6c7643e467eb626b8a1364b1030327de0", size = 72504, upload-time = "2026-03-27T03:49:45.668Z" },
+]
+
+[[package]]
+name = "pydantic-handlebars"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/16/d41768bd3fd77e6250c20be11a3e68fee5fff07c3356455e6708f6a60f2a/pydantic_handlebars-0.1.0.tar.gz", hash = "sha256:1931c54946add1b5e3796c9bf6a005ed7662cef0109bb05c352f0b3d031a1260", size = 159826, upload-time = "2026-03-01T20:00:17.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5f/86b1630be61bdebf253c2f953a6c3f073ec21bb0725565ea3896802e1ca3/pydantic_handlebars-0.1.0-py3-none-any.whl", hash = "sha256:8a436fe8bc607295eb04bec58bd6e2c9498c9e069c557ff0b505e3d568c783bc", size = 40890, upload-time = "2026-03-01T20:00:16.106Z" },
 ]
 
 [[package]]
@@ -4402,7 +4420,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.20.0"
+version = "1.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc", marker = "python_full_version >= '3.10'" },
@@ -4411,13 +4429,13 @@ dependencies = [
     { name = "types-protobuf", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/db/7d5118d28b0918888e1ec98f56f659fdb006351e06d95f30f4274962a76f/temporalio-1.20.0.tar.gz", hash = "sha256:5a6a85b7d298b7359bffa30025f7deac83c74ac095a4c6952fbf06c249a2a67c", size = 1850498, upload-time = "2025-11-25T21:25:20.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/b1/7d9b3104ab7994e7d49e765b92495aaff44810b1e066c874c284a93ebd55/temporalio-1.24.0.tar.gz", hash = "sha256:e534e2e71b4a721193ec4ff3dae521146d093554bd47a64f5605d4ca33e56718", size = 2040485, upload-time = "2026-03-23T15:33:33.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/1b/e69052aa6003eafe595529485d9c62d1382dd5e671108f1bddf544fb6032/temporalio-1.20.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fba70314b4068f8b1994bddfa0e2ad742483f0ae714d2ef52e63013ccfd7042e", size = 12061638, upload-time = "2025-11-25T21:24:57.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3b/3e8c67ed7f23bedfa231c6ac29a7a9c12b89881da7694732270f3ecd6b0c/temporalio-1.20.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffc5bb6cabc6ae67f0bfba44de6a9c121603134ae18784a2ff3a7f230ad99080", size = 11562603, upload-time = "2025-11-25T21:25:01.721Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/be/ed0cc11702210522a79e09703267ebeca06eb45832b873a58de3ca76b9d0/temporalio-1.20.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1e80c1e4cdf88fa8277177f563edc91466fe4dc13c0322f26e55c76b6a219e6", size = 11824016, upload-time = "2025-11-25T21:25:06.771Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/97/09c5cafabc80139d97338a2bdd8ec22e08817dfd2949ab3e5b73565006eb/temporalio-1.20.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba92d909188930860c9d89ca6d7a753bc5a67e4e9eac6cea351477c967355eed", size = 12189521, upload-time = "2025-11-25T21:25:12.091Z" },
-    { url = "https://files.pythonhosted.org/packages/11/23/5689c014a76aff3b744b3ee0d80815f63b1362637814f5fbb105244df09b/temporalio-1.20.0-cp310-abi3-win_amd64.whl", hash = "sha256:eacfd571b653e0a0f4aa6593f4d06fc628797898f0900d400e833a1f40cad03a", size = 12745027, upload-time = "2025-11-25T21:25:16.827Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/30517c21d6155bce1c3dc0e420db48da0231230dbc683f40ab6d5fe22b37/temporalio-1.24.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7f11e7b4f4d09bafba499b43188353e23dc128b1fe3f3160014476e3dce70760", size = 12223918, upload-time = "2026-03-23T15:33:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/73/d0/11aa103bde794524008c1850a84e06cde98698395ca1f8b12e1bd2390aa8/temporalio-1.24.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:5cff75a0ca922575b808a7fca1b0de38f6eea061f49e026664b8be9d5bb06ab8", size = 11708887, upload-time = "2026-03-23T15:33:11.67Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f4/774b56100e6bb94e3757ec96fb5c2bc62d42defc7d6de0ee35a12273827a/temporalio-1.24.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee7c13b6724dd0c304aa846aecf6da72a8550f4ade40a0a7f6dcc1c92ef35710", size = 12028303, upload-time = "2026-03-23T15:33:18.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/91/c05d0e9c2432fe8b1ea0d6fae321866ee49a320ad5e494e6ec9424ca5c28/temporalio-1.24.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa71b9bfa42f951dd04ade97ce7f92ecedee8903047b4b41b122bb8cbd87a337", size = 12375155, upload-time = "2026-03-23T15:33:24.234Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/97/5c939e4609c164c8690a3b5a135eb828d531de8ef63ff447a2a439c0b0fb/temporalio-1.24.0-cp310-abi3-win_amd64.whl", hash = "sha256:52f6833647eceddbebcc376e2ea663a9f73b2b3a42675f503aeb27c98fd4daeb", size = 12720174, upload-time = "2026-03-23T15:33:30.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- align the SDK surface and examples to Codex 0.117.0 and bump package metadata/changelog
- expand the app server wrapper/test coverage and finish the PydanticAI adapter fixes from review
- add regression tests for thinking propagation, streaming request preparation parity, and camelCase hook item normalization

## Testing
- `python scripts/run_ci_checks.py`
- `uv run pytest -q`
- `uv run pytest --cov=codex_sdk --cov-report=term-missing -q`
- `uv run mypy src`
- `uv run flake8 src tests`

## Notes
- vendor binary refreshes were validated locally via `scripts/setup_binary.py --verify-only` and left out of the commit/PR
- canonical release flow here is to merge to `main`, then tag `main` as `v0.117.0` so the Release workflow creates the GitHub release and the Publish workflow pushes to PyPI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-server endpoints for thread shell commands, background terminal cleanup, and filesystem watch/unwatch.
  * Typed thread hooks for lifecycle and item events; per-run thinking/reasoning configuration and mapping.
  * Option to opt out specific notification families per connection; extended endpoint filters/parameters.

* **Documentation**
  * SDK release notes, README, and examples updated to show typed outputs, hooks, thinking settings, and new endpoints.

* **Tests**
  * Added coverage for hooks, thinking mapping, new endpoints, and session/stream behaviors.

* **Updated Dependencies**
  * PydanticAI requirement bumped to >=1.73.0,<2 (dev pinned to 1.73.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->